### PR TITLE
Fix subscribe method spec for changeProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+- fixed: Fix subscribe method spec for change protocol.
+
 ## 1.0.0 (2025-02-02)

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -189,7 +189,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
                   if (!success) return 0 // Failed for whatever reason
 
                   // If the plugin can't scan, let the client do it:
-                  if (pluginRow.plugin.scanAddress == null) return 0
+                  if (pluginRow.plugin.scanAddress == null) return 2
 
                   const changed = await pluginRow.plugin
                     .scanAddress(address, checkpoint)

--- a/test/hub.test.ts
+++ b/test/hub.test.ts
@@ -133,7 +133,7 @@ describe('AddressHub', function () {
     const result = await changeClient.remoteMethods.subscribe([
       [UNSCANNABLE_PLUGIN_ID, TEST_ADDRESS]
     ])
-    expect(result).toEqual([0])
+    expect(result).toEqual([2])
   })
   test('subscribe unscannable plugin with checkpoint', async function () {
     await waitForExpect(() => {
@@ -142,7 +142,7 @@ describe('AddressHub', function () {
     const result = await changeClient.remoteMethods.subscribe([
       [UNSCANNABLE_PLUGIN_ID, TEST_ADDRESS, HIGH_CHECKPOINT]
     ])
-    expect(result).toEqual([0])
+    expect(result).toEqual([2])
   })
 
   test('subscription life-cycle', async function () {


### PR DESCRIPTION
The protocol should return a `2` if a plugin doesn't implement `scanAddress`, not `0`.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210114225628846