### PR TITLE
Sam/ws transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: Added flexible service key matching with URL templating.
 - changed: Migrated to JSON-based logs using Pino library.
 - removed: Removed plugins to reduce load: abstract, amoy, arbitrum, avalanche, base, bobevm, celo, ethereumclassic, ethereumpow, fantom, filecoinfevm, filecoinfevmcalibration, holesky, hyperevm, pulsechain, rsk, sepolia, sonic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Added flexible service key matching with URL templating.
+- added: Added support for WebSocket transports for evmRpc plugin.
 - changed: Migrated to JSON-based logs using Pino library.
 - changed: Use serviceKeys for nownodes API key.
 - removed: Removed plugins to reduce load: abstract, amoy, arbitrum, avalanche, base, bobevm, celo, ethereumclassic, ethereumpow, fantom, filecoinfevm, filecoinfevmcalibration, holesky, hyperevm, pulsechain, rsk, sepolia, sonic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Migrated to JSON-based logs using Pino library.
+
 ## 0.2.6 (2025-12-10)
 
 ## 0.2.5 (2025-12-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - changed: Migrated to JSON-based logs using Pino library.
+- removed: Removed plugins to reduce load: abstract, amoy, arbitrum, avalanche, base, bobevm, celo, ethereumclassic, ethereumpow, fantom, filecoinfevm, filecoinfevmcalibration, holesky, hyperevm, pulsechain, rsk, sepolia, sonic.
 
 ## 0.2.6 (2025-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: Added flexible service key matching with URL templating.
 - changed: Migrated to JSON-based logs using Pino library.
+- changed: Use serviceKeys for nownodes API key.
 - removed: Removed plugins to reduce load: abstract, amoy, arbitrum, avalanche, base, bobevm, celo, ethereumclassic, ethereumpow, fantom, filecoinfevm, filecoinfevmcalibration, holesky, hyperevm, pulsechain, rsk, sepolia, sonic.
 
 ## 0.2.6 (2025-12-10)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,75 @@
+# Change Server Logging
+
+## Implementation
+
+Uses Pino with a base logger and child loggers for scoping. Located in `src/util/logger.ts`.
+
+### API
+
+```typescript
+import { logger, makeLogger } from './util/logger'
+
+// Direct use of base logger for simple cases:
+logger.info({ port: 3000 }, 'server started')
+
+// For code plugins (blockbook, evmRpc):
+const pluginLogger = makeLogger('blockbook', 'ethereum') // scope, chainPluginId
+
+// For non-plugin code:
+const socketLogger = makeLogger('socket') // scope only
+
+// Returns a pino.Logger - use standard Pino API:
+pluginLogger.info('message')
+pluginLogger.warn('message')
+pluginLogger.error('message')
+
+// Pass an object with extra fields:
+pluginLogger.info({ ip: '1.2.3.4' }, 'connected')
+pluginLogger.info({ blockNum: '12345' }, 'block')
+```
+
+### Output Format
+
+JSON with these fields:
+
+- `level` - numeric level (30=info, 40=warn, 50=error)
+- `time` - numeric epoch milliseconds
+- `scope` - scope identifier (code plugin name: "blockbook", "evmRpc", "socket", "server")
+- `chainPluginId` - chain plugin ID (optional, e.g., "ethereum", "arbitrum")
+- `pid` - process ID (for socket events)
+- `sid` - socket ID (for socket events, identifies the connection)
+- `msg` - text message (Pino default key)
+- Additional fields from passed objects
+
+Example:
+
+```json
+{"level":30,"time":1735654281000,"scope":"blockbook","chainPluginId":"bitcoin","blockNum":"876543","msg":"block"}
+{"level":30,"time":1735654281000,"scope":"socket","pid":20812,"sid":396,"ip":"192.168.1.1","msg":"connected"}
+{"level":50,"time":1735654281000,"scope":"evmRpc","chainPluginId":"ethereum","msg":"watchBlocks error: connection timeout"}
+```
+
+### pino-pretty Support
+
+Logs are compatible with pino-pretty for human-readable output during development:
+
+```bash
+node src/index.js | pino-pretty --translateTime
+# Or use -t shorthand:
+node src/index.js | pino-pretty -t
+```
+
+## Logged Events
+
+1. **WebSocket connection established** - scope: `socket`, includes pid, sid, IP
+2. **Addresses subscribed** - scope: `socket`, includes pid, sid, IP, first 6 chars of addresses, pluginId, checkpoint
+3. **Block found** - scope: code plugin, includes `chainPluginId`, block number
+4. **Transaction detected** - scope: code plugin, includes `chainPluginId`, first 6 chars of address and txid
+5. **Update sent** - scope: `socket`, includes pid, sid, IP, pluginId, address (6 chars), checkpoint
+
+## Notes
+
+- All output goes to stdout for logrotate compatibility
+- Uses Pino's `.child()` pattern for efficient scoped logging
+- Logging is disabled when `NODE_ENV=test`
+- Reserved fields (`time`, `scope`) passed in log objects are automatically renamed with a `_` suffix to avoid conflicts (e.g., `time` becomes `time_`)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -7,5 +7,7 @@ jest.mock('./src/serverConfig', () => ({
       'api.etherscan.io': ['JYMB141VYKJ2KPVMYJUZC8PXGWKUFVFX8N'],
       'eth.blockscout.com': []
     }
-  }
+  },
+  // Pass through URL unchanged in tests (no replacements)
+  replaceUrlParams: (url: string) => url
 }))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clipanion": "^3.2.0-rc.3",
     "edge-server-tools": "^0.2.19",
     "node-fetch": "^2.6.0",
+    "pino": "^10.2.0",
     "prom-client": "^15.1.0",
     "serverlet": "^0.1.1",
     "viem": "^2.27.0",

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -10,7 +10,6 @@ import {
 } from './types/changeProtocol'
 import { getAddressPrefix } from './util/addressUtils'
 import { makeLogger } from './util/logger'
-import { stackify } from './util/stackify'
 
 const pluginGauge = new Gauge({
   name: 'change_plugin_count',
@@ -87,15 +86,17 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
         const socketInfo = codecMap.get(socketId)
         if (socketInfo == null) continue
         const { codec, ip } = socketInfo
-        logger.info({
-          pid: process.pid,
-          sid: socketId,
-          ip,
-          pluginId,
-          addr: getAddressPrefix(address),
-          checkpoint,
-          msg: 'update'
-        })
+        logger.info(
+          {
+            pid: process.pid,
+            sid: socketId,
+            ip,
+            pluginId,
+            addr: getAddressPrefix(address),
+            checkpoint
+          },
+          'update'
+        )
         codec.remoteMethods.update([pluginId, address, checkpoint])
       }
     })
@@ -109,14 +110,16 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
           const socketInfo = codecMap.get(socketId)
           if (socketInfo == null) continue
           const { codec, ip } = socketInfo
-          logger.info({
-            pid: process.pid,
-            sid: socketId,
-            ip,
-            pluginId,
-            addr: getAddressPrefix(address),
-            msg: 'subLost'
-          })
+          logger.info(
+            {
+              pid: process.pid,
+              sid: socketId,
+              ip,
+              pluginId,
+              addr: getAddressPrefix(address)
+            },
+            'subLost'
+          )
           codec.remoteMethods.subLost([pluginId, address])
         }
         pluginRow.addressSubscriptions.delete(address)
@@ -174,11 +177,11 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
       connectionGauge.inc()
       const pid = process.pid
       const sid = socketId
-      logger.info({ pid, sid, ip, msg: 'connected' })
+      logger.info({ pid, sid, ip }, 'connected')
 
       const codec = changeProtocol.makeServerCodec({
         handleError(error) {
-          logger.error({ pid, sid, ip, msg: `send error: ${String(error)}` })
+          logger.error({ pid, sid, ip, err: error }, 'send error')
           ws.close(1011, 'Internal error')
         },
 
@@ -196,7 +199,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
               addr: getAddressPrefix(address),
               checkpoint
             }))
-            logger.info({ pid, sid, ip, subs, msg: 'subscribe' })
+            logger.info({ pid, sid, ip, subs }, 'subscribe')
 
             // Do the initial scan:
             const result = await Promise.all(
@@ -220,12 +223,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
                   const changed = await pluginRow.plugin
                     .scanAddress(address, checkpoint)
                     .catch(error => {
-                      logger.warn({
-                        pid,
-                        sid,
-                        ip,
-                        msg: 'Scan address failed: ' + stackify(error)
-                      })
+                      logger.warn({ pid, sid, ip, err: error }, 'Scan address failed')
                       return true
                     })
                   return changed ? 2 : 1
@@ -237,13 +235,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
           },
 
           async unsubscribe(params: SubscribeParams[]): Promise<undefined> {
-            logger.info({
-              pid,
-              sid,
-              ip,
-              count: params.length,
-              msg: 'unsubscribe'
-            })
+            logger.info({ pid, sid, ip, count: params.length }, 'unsubscribe')
 
             for (const param of params) {
               const [pluginId, address] = param
@@ -279,7 +271,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
           }
         }
 
-        logger.info({ pid, sid, ip, subs, msg: 'closed' })
+        logger.info({ pid, sid, ip, subs }, 'closed')
         connectionGauge.dec()
 
         // Cleanup the server codec:
@@ -298,12 +290,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
             if (socketIds.size < 1) {
               unsubscribeClientsToPluginAddress(pluginRow, address).catch(
                 error => {
-                  logger.error({
-                    pid,
-                    sid,
-                    ip,
-                    msg: `unsubscribe error: ${String(error)}`
-                  })
+                  logger.error({ pid, sid, ip, err: error }, 'unsubscribe error')
                 }
               )
             }
@@ -312,12 +299,7 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
       })
 
       ws.on('error', error => {
-        logger.error({
-          pid,
-          sid,
-          ip,
-          msg: `connection error: ${String(error)}`
-        })
+        logger.error({ pid, sid, ip, err: error }, 'connection error')
       })
 
       ws.on('message', message => {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -2,13 +2,14 @@ import { Counter, Gauge } from 'prom-client'
 import WebSocket from 'ws'
 
 import { messageToString } from './messageToString'
-import { Logger } from './types'
 import { AddressPlugin } from './types/addressPlugin'
 import {
   changeProtocol,
   SubscribeParams,
   SubscribeResult
 } from './types/changeProtocol'
+import { getAddressPrefix } from './util/addressUtils'
+import { makeLogger } from './util/logger'
 import { stackify } from './util/stackify'
 
 const pluginGauge = new Gauge({
@@ -35,13 +36,12 @@ const eventCounter = new Counter({
 })
 
 export interface AddressHub {
-  handleConnection: (ws: WebSocket) => void
+  handleConnection: (ws: WebSocket, ip: string) => void
   destroy: () => void
 }
 
 export interface AddressHubOpts {
   plugins: AddressPlugin[]
-  logger?: Logger
 }
 
 interface PluginRow {
@@ -58,13 +58,15 @@ interface PluginRow {
  */
 export function makeAddressHub(opts: AddressHubOpts): AddressHub {
   const { plugins } = opts
+  const logger = makeLogger('socket')
   let nextSocketId = 0
 
-  // Maps socketId to changeProtocol server codec:
-  const codecMap = new Map<
-    number,
-    ReturnType<typeof changeProtocol.makeServerCodec>
-  >()
+  // Maps socketId to codec and IP info:
+  interface SocketInfo {
+    codec: ReturnType<typeof changeProtocol.makeServerCodec>
+    ip: string
+  }
+  const codecMap = new Map<number, SocketInfo>()
 
   // Maps pluginId to PluginRow:
   const pluginMap = new Map<string, PluginRow>()
@@ -82,9 +84,18 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
       const socketIds = pluginRow.addressSubscriptions.get(address)
       if (socketIds == null) return
       for (const socketId of socketIds) {
-        const codec = codecMap.get(socketId)
-        if (codec == null) continue
-        console.log(`WebSocket ${process.pid}.${socketId} update`)
+        const socketInfo = codecMap.get(socketId)
+        if (socketInfo == null) continue
+        const { codec, ip } = socketInfo
+        logger.info({
+          pid: process.pid,
+          sid: socketId,
+          ip,
+          pluginId,
+          addr: getAddressPrefix(address),
+          checkpoint,
+          msg: 'update'
+        })
         codec.remoteMethods.update([pluginId, address, checkpoint])
       }
     })
@@ -95,8 +106,17 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
         const socketIds = pluginRow.addressSubscriptions.get(address)
         if (socketIds == null) continue
         for (const socketId of socketIds) {
-          const codec = codecMap.get(socketId)
-          if (codec == null) continue
+          const socketInfo = codecMap.get(socketId)
+          if (socketInfo == null) continue
+          const { codec, ip } = socketInfo
+          logger.info({
+            pid: process.pid,
+            sid: socketId,
+            ip,
+            pluginId,
+            addr: getAddressPrefix(address),
+            msg: 'subLost'
+          })
           codec.remoteMethods.subLost([pluginId, address])
         }
         pluginRow.addressSubscriptions.delete(address)
@@ -148,28 +168,17 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
   }
 
   return {
-    handleConnection(ws: WebSocket): void {
+    handleConnection(ws: WebSocket, ip: string): void {
       const socketId = nextSocketId++
 
-      const logPrefix = `WebSocket ${process.pid}.${socketId} `
-      const logger: Logger = {
-        log: (...args: unknown[]): void => {
-          opts.logger?.log(logPrefix, ...args)
-        },
-        error: (...args: unknown[]): void => {
-          opts.logger?.error(logPrefix, ...args)
-        },
-        warn: (...args: unknown[]): void => {
-          opts.logger?.warn(logPrefix, ...args)
-        }
-      }
-
       connectionGauge.inc()
-      logger.log('connected')
+      const pid = process.pid
+      const sid = socketId
+      logger.info({ pid, sid, ip, msg: 'connected' })
 
       const codec = changeProtocol.makeServerCodec({
         handleError(error) {
-          logger.error(`send error: ${String(error)}`)
+          logger.error({ pid, sid, ip, msg: `send error: ${String(error)}` })
           ws.close(1011, 'Internal error')
         },
 
@@ -181,7 +190,13 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
           async subscribe(
             params: SubscribeParams[]
           ): Promise<SubscribeResult[]> {
-            logger.log(`subscribing ${params.length}`)
+            // Log all subscriptions in one line
+            const subs = params.map(([pluginId, address, checkpoint]) => ({
+              pluginId,
+              addr: getAddressPrefix(address),
+              checkpoint
+            }))
+            logger.info({ pid, sid, ip, subs, msg: 'subscribe' })
 
             // Do the initial scan:
             const result = await Promise.all(
@@ -205,7 +220,12 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
                   const changed = await pluginRow.plugin
                     .scanAddress(address, checkpoint)
                     .catch(error => {
-                      logger.warn('Scan address failed: ' + stackify(error))
+                      logger.warn({
+                        pid,
+                        sid,
+                        ip,
+                        msg: 'Scan address failed: ' + stackify(error)
+                      })
                       return true
                     })
                   return changed ? 2 : 1
@@ -213,13 +233,17 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
               )
             )
 
-            logger.log(`subscribed ${params.length}`)
-
             return result
           },
 
           async unsubscribe(params: SubscribeParams[]): Promise<undefined> {
-            logger.log(`unsubscribed ${params.length}`)
+            logger.info({
+              pid,
+              sid,
+              ip,
+              count: params.length,
+              msg: 'unsubscribe'
+            })
 
             for (const param of params) {
               const [pluginId, address] = param
@@ -241,11 +265,21 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
         }
       })
 
-      // Save the codec for notifications:
-      codecMap.set(socketId, codec)
+      // Save the codec and IP for notifications:
+      codecMap.set(socketId, { codec, ip })
 
       ws.on('close', () => {
-        logger.log(`closed`)
+        // Collect subscriptions for logging before cleanup:
+        const subs: Array<{ pluginId: string; addr: string }> = []
+        for (const [pluginId, pluginRow] of pluginMap.entries()) {
+          for (const [address, socketIds] of pluginRow.addressSubscriptions) {
+            if (socketIds.has(socketId)) {
+              subs.push({ pluginId, addr: getAddressPrefix(address) })
+            }
+          }
+        }
+
+        logger.info({ pid, sid, ip, subs, msg: 'closed' })
         connectionGauge.dec()
 
         // Cleanup the server codec:
@@ -264,7 +298,12 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
             if (socketIds.size < 1) {
               unsubscribeClientsToPluginAddress(pluginRow, address).catch(
                 error => {
-                  console.error('unsubscribe error:', error)
+                  logger.error({
+                    pid,
+                    sid,
+                    ip,
+                    msg: `unsubscribe error: ${String(error)}`
+                  })
                 }
               )
             }
@@ -273,7 +312,12 @@ export function makeAddressHub(opts: AddressHubOpts): AddressHub {
       })
 
       ws.on('error', error => {
-        logger.error(`connection error: ${String(error)}`)
+        logger.error({
+          pid,
+          sid,
+          ip,
+          msg: `connection error: ${String(error)}`
+        })
       })
 
       ws.on('message', message => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ function manageServers(): void {
   // Restart workers when they exit:
   cluster.on('exit', (worker, code, signal) => {
     const { pid = '?' } = worker.process
-    logger.info({ pid, code, signal, msg: 'worker died' })
+    logger.info({ pid, code, signal }, 'worker died')
     cluster.fork()
   })
 
@@ -47,7 +47,7 @@ function manageServers(): void {
       })
   })
   httpServer.listen(metricsPort, metricsHost)
-  logger.info({ port: metricsPort, msg: 'metrics server listening' })
+  logger.info({ port: metricsPort }, 'metrics server listening')
 }
 
 async function server(): Promise<void> {
@@ -58,7 +58,7 @@ async function server(): Promise<void> {
     port: listenPort,
     host: listenHost
   })
-  logger.info({ port: listenPort, msg: 'websocket server listening' })
+  logger.info({ port: listenPort }, 'websocket server listening')
 
   const hub = makeAddressHub({ plugins: allPlugins })
   wss.on('connection', (ws, req) => {
@@ -75,11 +75,11 @@ async function server(): Promise<void> {
 
   // Graceful shutdown handler
   const shutdown = (): void => {
-    logger.info({ pid: process.pid, msg: 'shutting down' })
+    logger.info({ pid: process.pid }, 'shutting down')
 
     // Stop accepting new connections
     wss.close(() => {
-      logger.info({ pid: process.pid, msg: 'websocket server closed' })
+      logger.info({ pid: process.pid }, 'websocket server closed')
     })
 
     // Close all existing client connections
@@ -90,7 +90,7 @@ async function server(): Promise<void> {
     // Clean up plugin resources (timers, WebSocket connections, etc.)
     hub.destroy()
 
-    logger.info({ pid: process.pid, msg: 'cleanup complete' })
+    logger.info({ pid: process.pid }, 'cleanup complete')
     process.exit(0)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import WebSocket from 'ws'
 
 import { makeAddressHub } from './hub'
 import { serverConfig } from './serverConfig'
+import { makeLogger } from './util/logger'
+
+const logger = makeLogger('server')
 
 const aggregatorRegistry = new AggregatorRegistry()
 
@@ -24,7 +27,7 @@ function manageServers(): void {
   // Restart workers when they exit:
   cluster.on('exit', (worker, code, signal) => {
     const { pid = '?' } = worker.process
-    console.log(`Worker ${pid} died with code ${code} and signal ${signal}`)
+    logger.info({ pid, code, signal, msg: 'worker died' })
     cluster.fork()
   })
 
@@ -44,7 +47,7 @@ function manageServers(): void {
       })
   })
   httpServer.listen(metricsPort, metricsHost)
-  console.log(`Metrics server listening on port ${metricsPort}`)
+  logger.info({ port: metricsPort, msg: 'metrics server listening' })
 }
 
 async function server(): Promise<void> {
@@ -55,18 +58,28 @@ async function server(): Promise<void> {
     port: listenPort,
     host: listenHost
   })
-  console.log(`WebSocket server listening on port ${listenPort}`)
+  logger.info({ port: listenPort, msg: 'websocket server listening' })
 
-  const hub = makeAddressHub({ plugins: allPlugins, logger: console })
-  wss.on('connection', ws => hub.handleConnection(ws))
+  const hub = makeAddressHub({ plugins: allPlugins })
+  wss.on('connection', (ws, req) => {
+    // Extract IP from X-Forwarded-For header (if behind proxy) or socket
+    const forwardedFor = req.headers['x-forwarded-for']
+    const ip =
+      (typeof forwardedFor === 'string'
+        ? forwardedFor.split(',')[0].trim()
+        : undefined) ??
+      req.socket.remoteAddress ??
+      'unknown'
+    hub.handleConnection(ws, ip)
+  })
 
   // Graceful shutdown handler
   const shutdown = (): void => {
-    console.log(`Worker ${process.pid} shutting down...`)
+    logger.info({ pid: process.pid, msg: 'shutting down' })
 
     // Stop accepting new connections
     wss.close(() => {
-      console.log(`Worker ${process.pid} WebSocket server closed`)
+      logger.info({ pid: process.pid, msg: 'websocket server closed' })
     })
 
     // Close all existing client connections
@@ -77,7 +90,7 @@ async function server(): Promise<void> {
     // Clean up plugin resources (timers, WebSocket connections, etc.)
     hub.destroy()
 
-    console.log(`Worker ${process.pid} cleanup complete`)
+    logger.info({ pid: process.pid, msg: 'cleanup complete' })
     process.exit(0)
   }
 
@@ -86,6 +99,6 @@ async function server(): Promise<void> {
 }
 
 main().catch(error => {
-  console.error(error)
+  logger.error({ err: error }, 'main error')
   process.exit(1)
 })

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -34,86 +34,6 @@ export const allPlugins = [
     url: 'wss://qtum-blockbook.nownodes.io/wss/{nowNodesApiKey}'
   }),
 
-  // Ethereum family:
-  makeEvmRpc({
-    pluginId: 'abstract',
-    urls: [
-      'https://abstract.api.onfinality.io/public' // yellow privacy
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 2741,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'amoy',
-    urls: [
-      'https://api.zan.top/polygon-amoy', // yellow privacy
-      'https://polygon-amoy-public.nodies.app', // yellow privacy
-      'https://polygon-amoy.api.onfinality.io/public' // yellow privacy
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'arbitrum',
-    urls: [
-      'https://arbitrum-one-rpc.publicnode.com', // green privacy
-      'https://arbitrum.meowrpc.com', // green privacy
-      'https://public-arb-mainnet.fastnode.io', // green privacy
-      'https://api.zan.top/arb-one', // yellow privacy
-      'https://arbitrum-one-public.nodies.app', // yellow privacy
-      'https://arbitrum.api.onfinality.io/public', // yellow privacy
-      'https://rpc.poolz.finance/arbitrum' // yellow privacy
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 42161,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'avalanche',
-    urls: [
-      'https://0xrpc.io/avax', // green privacy
-      'https://avalanche-c-chain-rpc.publicnode.com', // green privacy
-      'https://avax.meowrpc.com', // green privacy
-      'https://endpoints.omniatech.io/v1/avax/mainnet/public', // green privacy
-      'https://api.zan.top/avax-mainnet/ext/bc/C/rpc', // yellow privacy
-      'https://avalanche-public.nodies.app/ext/bc/C/rpc', // yellow privacy
-      'https://avalanche.api.onfinality.io/public/ext/bc/C/rpc', // yellow privacy
-      'https://rpc.poolz.finance/avalanche' // yellow privacy
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 43114,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'base',
-    urls: [
-      'https://base-rpc.publicnode.com', // green privacy
-      'https://base.llamarpc.com', // green privacy
-      'https://base.meowrpc.com', // green privacy
-      'https://api.zan.top/base-mainnet', // yellow privacy
-      'https://base-public.nodies.app', // yellow privacy
-      'https://base.api.onfinality.io/public', // yellow privacy
-      'https://rpc.poolz.finance/base' // yellow privacy
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 8453,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
   makeEvmRpc({
     pluginId: 'binancesmartchain',
     urls: [
@@ -141,35 +61,12 @@ export const allPlugins = [
     ]
   }),
   makeEvmRpc({
-    pluginId: 'bobevm',
-    urls: ['https://rpc.gobob.xyz'], // original URL - all chainlist RPCs failed
-    scanAdapters: [
-      { type: 'etherscan-v1', urls: ['https://explorer.gobob.xyz'] }
-    ]
-  }),
-  makeEvmRpc({
     pluginId: 'botanix',
     urls: ['https://rpc.ankr.com/botanix_mainnet'], // green privacy
     scanAdapters: [
       {
         type: 'etherscan-v1',
         urls: ['https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'celo',
-    urls: [
-      'https://celo-json-rpc.stakely.io', // green privacy
-      'https://celo.api.onfinality.io/public', // yellow privacy
-      'https://rpc.ankr.com/celo' // yellow privacy
-    ],
-    scanAdapters: [
-      { type: 'etherscan-v1', urls: ['https://explorer.celo.org/mainnet'] },
-      {
-        type: 'etherscan-v2',
-        chainId: 42220,
-        urls: ['https://api.etherscan.io']
       }
     ]
   }),
@@ -198,64 +95,6 @@ export const allPlugins = [
         type: 'etherscan-v2',
         chainId: 1,
         urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'ethereumclassic',
-    urls: [
-      'https://0xrpc.io/etc', // green privacy
-      'https://etc.rivet.link', // green privacy
-      'https://ethereum-classic-mainnet.gateway.tatum.io' // green privacy
-    ],
-    scanAdapters: [
-      { type: 'etherscan-v1', urls: ['https://etc.blockscout.com'] }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'ethereumpow',
-    urls: ['https://mainnet.ethereumpow.org'] // no chainlist RPCs found, keeping original
-  }),
-  makeEvmRpc({
-    pluginId: 'fantom',
-    urls: [
-      'https://endpoints.omniatech.io/v1/fantom/mainnet/public', // green privacy
-      'https://fantom-json-rpc.stakely.io', // green privacy
-      'https://api.zan.top/ftm-mainnet', // yellow privacy
-      'https://fantom-public.nodies.app', // yellow privacy
-      'https://fantom.api.onfinality.io/public' // yellow privacy
-    ],
-    scanAdapters: [{ type: 'etherscan-v1', urls: ['https://ftmscout.com/'] }]
-  }),
-  makeEvmRpc({
-    pluginId: 'filecoinfevm',
-    urls: [
-      'https://filecoin.chainup.net/rpc/v1', // yellow privacy
-      'https://rpc.ankr.com/filecoin' // yellow privacy
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'filecoinfevmcalibration',
-    urls: ['https://rpc.ankr.com/filecoin_testnet'] // original URL - all chainlist RPCs failed
-  }),
-  makeEvmRpc({
-    pluginId: 'holesky',
-    urls: ['https://ethereum-holesky-rpc.publicnode.com'], // original URL - all chainlist RPCs failed
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 17000,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'hyperevm',
-    urls: ['https://rpc.hyperliquid.xyz/evm'], // no chainlist RPCs found, keeping original
-    scanAdapters: [
-      {
-        type: 'etherscan-v1',
-        urls: ['https://api.routescan.io/v2/network/mainnet/evm/999/etherscan']
       }
     ]
   }),
@@ -293,52 +132,6 @@ export const allPlugins = [
       {
         type: 'etherscan-v2',
         chainId: 137,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'pulsechain',
-    urls: [
-      'https://pulsechain-rpc.publicnode.com', // green privacy
-      'https://rpc.pulsechainrpc.com', // green privacy
-      'https://rpc.pulsechainstats.com' // yellow privacy
-    ],
-    scanAdapters: [
-      { type: 'etherscan-v1', urls: ['https://api.scan.pulsechain.com'] }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'rsk',
-    urls: ['https://public-node.rsk.co'], // original URL - all chainlist RPCs failed
-    scanAdapters: [
-      { type: 'etherscan-v1', urls: ['https://rootstock.blockscout.com/'] }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'sepolia',
-    urls: [
-      'https://0xrpc.io/sep', // green privacy
-      'https://ethereum-sepolia-rpc.publicnode.com', // green privacy
-      'https://api.zan.top/eth-sepolia', // yellow privacy
-      'https://eth-sepolia.api.onfinality.io/public', // yellow privacy
-      'https://ethereum-sepolia-public.nodies.app' // yellow privacy
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 11155111,
-        urls: ['https://api.etherscan.io']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'sonic',
-    urls: ['https://sonic-json-rpc.stakely.io'], // green privacy
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 146,
         urls: ['https://api.etherscan.io']
       }
     ]

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -29,6 +29,7 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'binancesmartchain',
     urls: [
+      authenticateUrl('wss://lb.drpc.org/ogrpc?network=bsc&dkey={{apiKey}}'),
       authenticateUrl('https://lb.drpc.org/ogrpc?network=bsc&dkey={{apiKey}}')
       // authenticateUrl('https://lb.drpc.live/bsc/{{apiKey}}')
     ],
@@ -42,7 +43,10 @@ export const allPlugins = [
   }),
   makeEvmRpc({
     pluginId: 'botanix',
-    urls: ['https://rpc.ankr.com/botanix_mainnet'], // green privacy
+    urls: [
+      'wss://rpc.ankr.com/botanix_mainnet',
+      'https://rpc.ankr.com/botanix_mainnet'
+    ], // green privacy
     scanAdapters: [
       {
         type: 'etherscan-v1',
@@ -53,6 +57,10 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'ethereum',
     urls: [
+      authenticateUrl('wss://mainnet.infura.io/ws/v3/{{apiKey}}'),
+      authenticateUrl(
+        'wss://lb.drpc.org/ogrpc?network=ethereum&dkey={{apiKey}}'
+      ),
       authenticateUrl('https://mainnet.infura.io/v3/{{apiKey}}'),
       authenticateUrl(
         'https://lb.drpc.org/ogrpc?network=ethereum&dkey={{apiKey}}'
@@ -74,6 +82,9 @@ export const allPlugins = [
     pluginId: 'optimism',
     urls: [
       authenticateUrl(
+        'wss://lb.drpc.org/ogrpc?network=optimism&dkey={{apiKey}}'
+      ),
+      authenticateUrl(
         'https://lb.drpc.org/ogrpc?network=optimism&dkey={{apiKey}}'
       )
       // authenticateUrl('https://lb.drpc.live/optimism/{{apiKey}}')
@@ -94,6 +105,9 @@ export const allPlugins = [
     pluginId: 'polygon',
     urls: [
       authenticateUrl(
+        'wss://lb.drpc.org/ogrpc?network=polygon&dkey={{apiKey}}'
+      ),
+      authenticateUrl(
         'https://lb.drpc.org/ogrpc?network=polygon&dkey={{apiKey}}'
       )
       // authenticateUrl('https://lb.drpc.live/polygon/{{apiKey}}')
@@ -109,6 +123,7 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'zksync',
     urls: [
+      authenticateUrl('wss://lb.drpc.org/ogrpc?network=zksync&dkey={{apiKey}}'),
       authenticateUrl(
         'https://lb.drpc.org/ogrpc?network=zksync&dkey={{apiKey}}'
       )

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -1,5 +1,6 @@
 import { serverConfig } from '../serverConfig'
 import { AddressPlugin } from '../types/addressPlugin'
+import { authenticateUrl } from '../util/authenticateUrl'
 import { BlockbookOptions, makeBlockbook } from './blockbook'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
@@ -37,20 +38,8 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'binancesmartchain',
     urls: [
-      'https://binance.llamarpc.com', // green privacy
-      'https://bsc-rpc.publicnode.com', // green privacy
-      'https://bsc.blockrazor.xyz', // green privacy
-      'https://bsc.meowrpc.com', // green privacy
-      'https://endpoints.omniatech.io/v1/bsc/mainnet/public', // green privacy
-      'https://public-bsc-mainnet.fastnode.io', // green privacy
-      'https://0.48.club', // yellow privacy
-      'https://api-bsc-mainnet-full.n.dwellir.com/2ccf18bf-2916-4198-8856-42172854353c', // yellow privacy
-      'https://api.zan.top/bsc-mainnet', // yellow privacy
-      'https://binance-smart-chain-public.nodies.app', // yellow privacy
-      'https://bnb.api.onfinality.io/public', // yellow privacy
-      'https://go.getblock.io/cc778cdbdf5c4b028ec9456e0e6c0cf3', // yellow privacy
-      'https://rpc-bsc.48.club', // yellow privacy
-      'https://rpc.poolz.finance/bsc' // yellow privacy
+      authenticateUrl('https://lb.drpc.org/ogrpc?network=bsc&dkey={{apiKey}}')
+      // authenticateUrl('https://lb.drpc.live/bsc/{{apiKey}}')
     ],
     scanAdapters: [
       {
@@ -73,60 +62,50 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'ethereum',
     urls: [
-      'https://0xrpc.io/eth', // green privacy
-      'https://endpoints.omniatech.io/v1/eth/mainnet/public', // green privacy
-      'https://eth.blockrazor.xyz', // green privacy
-      'https://eth.llamarpc.com', // green privacy
-      'https://eth.meowrpc.com', // green privacy
-      'https://eth.merkle.io', // green privacy
-      'https://ethereum-json-rpc.stakely.io', // green privacy
-      'https://ethereum-rpc.publicnode.com', // green privacy
-      'https://go.getblock.io/aefd01aa907c4805ba3c00a9e5b48c6b', // green privacy
-      'https://rpc.flashbots.net', // green privacy
-      'https://rpc.mevblocker.io', // green privacy
-      'https://rpc.payload.de', // green privacy
-      'https://api.zan.top/eth-mainnet', // yellow privacy
-      'https://eth.api.onfinality.io/public', // yellow privacy
-      'https://ethereum-public.nodies.app', // yellow privacy
-      'https://rpc.poolz.finance/eth' // yellow privacy
+      authenticateUrl('https://mainnet.infura.io/v3/{{apiKey}}'),
+      authenticateUrl(
+        'https://lb.drpc.org/ogrpc?network=ethereum&dkey={{apiKey}}'
+      )
     ],
     scanAdapters: [
       {
         type: 'etherscan-v2',
         chainId: 1,
         urls: ['https://api.etherscan.io']
+      },
+      {
+        type: 'etherscan-v1',
+        urls: ['https://api.routescan.io/v2/network/mainnet/evm/1/etherscan']
       }
     ]
   }),
   makeEvmRpc({
     pluginId: 'optimism',
     urls: [
-      'https://0xrpc.io/op', // green privacy
-      'https://endpoints.omniatech.io/v1/op/mainnet/public', // green privacy
-      'https://optimism-rpc.publicnode.com', // green privacy
-      'https://public-op-mainnet.fastnode.io', // green privacy
-      'https://api.zan.top/opt-mainnet', // yellow privacy
-      'https://optimism-public.nodies.app', // yellow privacy
-      'https://optimism.api.onfinality.io/public' // yellow privacy
+      authenticateUrl(
+        'https://lb.drpc.org/ogrpc?network=optimism&dkey={{apiKey}}'
+      )
+      // authenticateUrl('https://lb.drpc.live/optimism/{{apiKey}}')
     ],
     scanAdapters: [
       {
         type: 'etherscan-v2',
         chainId: 10,
         urls: ['https://api.etherscan.io']
+      },
+      {
+        type: 'etherscan-v1',
+        urls: ['https://api.routescan.io/v2/network/mainnet/evm/10/etherscan']
       }
     ]
   }),
   makeEvmRpc({
     pluginId: 'polygon',
     urls: [
-      'https://endpoints.omniatech.io/v1/matic/mainnet/public', // green privacy
-      'https://polygon-bor-rpc.publicnode.com', // green privacy
-      'https://polygon.meowrpc.com', // green privacy
-      'https://api.zan.top/polygon-mainnet', // yellow privacy
-      'https://polygon-public.nodies.app', // yellow privacy
-      'https://polygon.api.onfinality.io/public', // yellow privacy
-      'https://rpc.poolz.finance/polygon' // yellow privacy
+      authenticateUrl(
+        'https://lb.drpc.org/ogrpc?network=polygon&dkey={{apiKey}}'
+      )
+      // authenticateUrl('https://lb.drpc.live/polygon/{{apiKey}}')
     ],
     scanAdapters: [
       {
@@ -139,24 +118,20 @@ export const allPlugins = [
   makeEvmRpc({
     pluginId: 'zksync',
     urls: [
-      'https://rpc.ankr.com/zksync_era', // green privacy
-      'https://zksync.meowrpc.com', // green privacy
-      'https://api.zan.top/zksync-mainnet', // yellow privacy
-      'https://go.getblock.io/f76c09905def4618a34946bf71851542', // yellow privacy
-      'https://zksync.api.onfinality.io/public' // yellow privacy
+      authenticateUrl(
+        'https://lb.drpc.org/ogrpc?network=zksync&dkey={{apiKey}}'
+      )
+      // authenticateUrl('https://lb.drpc.live/zksync/{{apiKey}}')
     ],
     scanAdapters: [
-      {
-        type: 'etherscan-v1',
-        urls: [
-          'https://block-explorer-api.mainnet.zksync.io',
-          'https://zksync.blockscout.com'
-        ]
-      },
       {
         type: 'etherscan-v2',
         chainId: 324,
         urls: ['https://api.etherscan.io']
+      },
+      {
+        type: 'etherscan-v1',
+        urls: ['https://api.routescan.io/v2/network/mainnet/evm/324/etherscan']
       }
     ]
   }),

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -1,38 +1,29 @@
-import { serverConfig } from '../serverConfig'
-import { AddressPlugin } from '../types/addressPlugin'
 import { authenticateUrl } from '../util/authenticateUrl'
-import { BlockbookOptions, makeBlockbook } from './blockbook'
+import { makeBlockbook } from './blockbook'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
 
-function makeNowNode(opts: BlockbookOptions): AddressPlugin {
-  return makeBlockbook({
-    ...opts,
-    nowNodesApiKey: serverConfig.nowNodesApiKey
-  })
-}
-
 export const allPlugins = [
   // Bitcoin family:
-  makeNowNode({
+  makeBlockbook({
     pluginId: 'bitcoin',
-    url: 'wss://btcbook.nownodes.io/wss/{nowNodesApiKey}'
+    url: authenticateUrl('wss://btcbook.nownodes.io/wss/{{apiKey}}')
   }),
-  makeNowNode({
+  makeBlockbook({
     pluginId: 'bitcoincash',
-    url: 'wss://bchbook.nownodes.io/wss/{nowNodesApiKey}'
+    url: authenticateUrl('wss://bchbook.nownodes.io/wss/{{apiKey}}')
   }),
-  makeNowNode({
+  makeBlockbook({
     pluginId: 'dogecoin',
-    url: 'wss://dogebook.nownodes.io/wss/{nowNodesApiKey}'
+    url: authenticateUrl('wss://dogebook.nownodes.io/wss/{{apiKey}}')
   }),
-  makeNowNode({
+  makeBlockbook({
     pluginId: 'litecoin',
-    url: 'wss://ltcbook.nownodes.io/wss/{nowNodesApiKey}'
+    url: authenticateUrl('wss://ltcbook.nownodes.io/wss/{{apiKey}}')
   }),
-  makeNowNode({
+  makeBlockbook({
     pluginId: 'qtum',
-    url: 'wss://qtum-blockbook.nownodes.io/wss/{nowNodesApiKey}'
+    url: authenticateUrl('wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}')
   }),
 
   makeEvmRpc({

--- a/src/plugins/evmRpc.ts
+++ b/src/plugins/evmRpc.ts
@@ -63,11 +63,13 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
       logger.error({ err }, 'watchBlocks error')
     },
     onBlock: async block => {
-      logger.info({
-        blockNum: block.number.toString(),
-        msg: 'block',
-        numSubs: subscribedAddresses.size
-      })
+      logger.info(
+        {
+          blockNum: block.number.toString(),
+          numSubs: subscribedAddresses.size
+        },
+        'block'
+      )
 
       // Skip processing if no subscriptions
       if (subscribedAddresses.size === 0) {
@@ -103,11 +105,10 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
           event: ERC20_TRANSFER_EVENT
         })
         .catch(error => {
-          logger.error({
-            err: error,
-            blockNum: block.number.toString(),
-            msg: 'getLogs error'
-          })
+          logger.error(
+            { err: error, blockNum: block.number.toString() },
+            'getLogs error'
+          )
           throw error
         })
       transferLogs.forEach(log => {
@@ -202,23 +203,22 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
 
       // Emit update events for all affected subscribed addresses
       for (const originalAddress of addressesToUpdate) {
-        logger.info({
-          addr: getAddressPrefix(originalAddress),
-          msg: 'tx detected'
-        })
+        logger.info({ addr: getAddressPrefix(originalAddress) }, 'tx detected')
         emit('update', {
           address: originalAddress,
           checkpoint: block.number.toString()
         })
       }
-      logger.info({
-        blockNum: block.number.toString(),
-        msg: 'block processed',
-        internal: opts.includeInternal !== false,
-        traceBlock,
-        numSubs: subscribedAddresses.size,
-        numUpdates: addressesToUpdate.size
-      })
+      logger.info(
+        {
+          blockNum: block.number.toString(),
+          internal: opts.includeInternal !== false,
+          traceBlock,
+          numSubs: subscribedAddresses.size,
+          numUpdates: addressesToUpdate.size
+        },
+        'block processed'
+      )
     }
   })
 
@@ -239,7 +239,7 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
       if (scanAdapter == null) {
         // If no adapters are provided, then we have no way to implement
         // scanAddress.
-        logger.error({ msg: 'No scan adapters provided', pluginId })
+        logger.error({ pluginId }, 'No scan adapters provided')
         return true
       }
       const adapter = getScanAdapter(scanAdapter, logger)

--- a/src/plugins/evmRpc.ts
+++ b/src/plugins/evmRpc.ts
@@ -20,7 +20,7 @@ export interface EvmRpcOptions {
   urls: string[]
 
   /** The scan adapters to use for this plugin. */
-  scanAdapters?: ScanAdapterConfig[]
+  scanAdapters: ScanAdapterConfig[]
 
   /** Enable value-carrying internal transfer detection via traces (default `true`) */
   includeInternal?: boolean
@@ -227,12 +227,13 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
     },
     on,
     scanAddress: async (address, checkpoint): Promise<boolean> => {
-      // if no adapters are provided, then we have no way to implement
-      // scanAddress.
-      if (scanAdapters == null || scanAdapters.length === 0) {
+      const scanAdapter = pickRandom(scanAdapters)
+      if (scanAdapter == null) {
+        // If no adapters are provided, then we have no way to implement
+        // scanAddress.
+        logger.error({ msg: 'No scan adapters provided', pluginId })
         return true
       }
-      const scanAdapter = pickRandom(scanAdapters)
       const adapter = getScanAdapter(scanAdapter, logger)
       return await adapter(address, checkpoint)
     },

--- a/src/plugins/evmRpc.ts
+++ b/src/plugins/evmRpc.ts
@@ -2,8 +2,9 @@ import { createPublicClient, fallback, http, parseAbiItem } from 'viem'
 import { mainnet } from 'viem/chains'
 import { makeEvents } from 'yavent'
 
-import { Logger } from '../types'
 import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import { getAddressPrefix } from '../util/addressUtils'
+import { Logger, makeLogger } from '../util/logger'
 import { pickRandom } from '../util/pickRandom'
 import { makeEtherscanV1ScanAdapter } from '../util/scanAdapters/EtherscanV1ScanAdapter'
 import { makeEtherscanV2ScanAdapter } from '../util/scanAdapters/EtherscanV2ScanAdapter'
@@ -34,82 +35,36 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
 
   const [on, emit] = makeEvents<PluginEvents>()
 
-  // Track which URL is currently being used by the fallback transport
-  let activeUrl: string = pickRandom(urls)
-
-  // Create a logger that uses the active URL (sanitized for logging)
-  const getLogPrefix = (): string =>
-    `${pluginId} (${sanitizeUrlForLogging(activeUrl)}):`
-  const logger: Logger = {
-    log: (...args: unknown[]): void => {
-      console.log(getLogPrefix(), ...args)
-    },
-    error: (...args: unknown[]): void => {
-      console.error(getLogPrefix(), ...args)
-    },
-    warn: (...args: unknown[]): void => {
-      console.warn(getLogPrefix(), ...args)
-    }
-  }
+  const logger = makeLogger('evmRpc', pluginId)
 
   // Track subscribed addresses (normalized lowercase address -> original address)
   const subscribedAddresses = new Map<string, string>()
 
-  // Create a map to track which URL corresponds to which transport instance.
-  // Using WeakMap so transport instances can be garbage collected when no longer used.
-  const transportUrlMap = new WeakMap<object, string>()
-
   // Create fallback transport with all URLs
-  const transports = urls.map(url => {
-    const httpTransport = http(url)
-    // Wrap the transport factory to track URL mapping
-    return (config: any) => {
-      const transportInstance = httpTransport(config)
-      // Store the mapping from transport instance to URL
-      transportUrlMap.set(transportInstance, url)
-      return transportInstance
-    }
-  })
-  const transport = fallback(transports)
+  const transport = fallback(urls.map(url => http(url)))
 
   const client = createPublicClient({
     chain: mainnet,
     transport
   })
 
-  // Access the transport's onResponse callback after client creation to track which URL was used
-  // The transport is created internally, so we need to access it through the client's transport
-  const fallbackTransport = client.transport as any
-  if (fallbackTransport?.onResponse != null) {
-    fallbackTransport.onResponse(
-      ({
-        transport: usedTransport,
-        status
-      }: {
-        transport: any
-        status: 'success' | 'error'
-      }) => {
-        // When a transport succeeds, update the active URL
-        if (status === 'success' && usedTransport != null) {
-          const url = transportUrlMap.get(usedTransport)
-          if (url != null) {
-            activeUrl = url
-          }
-        }
-      }
-    )
-  }
-
   const unwatchBlocks = client.watchBlocks({
     includeTransactions: true,
     emitMissed: true,
-    onError: error => {
-      logger.error('watchBlocks error', error)
+    onError: err => {
+      logger.error({ err }, 'watchBlocks error')
     },
     onBlock: async block => {
-      logger.log('onBlock', block.number)
+      logger.info({
+        blockNum: block.number.toString(),
+        msg: 'block',
+        numSubs: subscribedAddresses.size
+      })
+
       // Skip processing if no subscriptions
-      if (subscribedAddresses.size === 0) return
+      if (subscribedAddresses.size === 0) {
+        return
+      }
 
       // Track which subscribed addresses have updates in this block
       const addressesToUpdate = new Set<string>()
@@ -134,10 +89,19 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
       })
 
       // Check ERC20 transfers
-      const transferLogs = await client.getLogs({
-        blockHash: block.hash,
-        event: ERC20_TRANSFER_EVENT
-      })
+      const transferLogs = await client
+        .getLogs({
+          blockHash: block.hash,
+          event: ERC20_TRANSFER_EVENT
+        })
+        .catch(error => {
+          logger.error({
+            err: error,
+            blockNum: block.number.toString(),
+            msg: 'getLogs error'
+          })
+          throw error
+        })
       transferLogs.forEach(log => {
         const normalizedFromAddress = log.args.from?.toLowerCase()
         const normalizedToAddress = log.args.to?.toLowerCase()
@@ -157,6 +121,7 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
         }
       })
 
+      let traceBlock = true
       // Internal native-value transfers via traces
       if (opts.includeInternal !== false) {
         const addressesFromTraces = new Set<string>()
@@ -181,6 +146,7 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
           }
         } catch (e) {
           // fall through to geth debug_traceTransaction
+          traceBlock = false
         }
 
         if (!traced) {
@@ -199,7 +165,10 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
                 ]
               })
             )
-          )
+          ).catch(error => {
+            logger.error({ err: error }, 'debug_traceTransaction error')
+            throw error
+          })
 
           const walk = (node: any): void => {
             if (node == null) return
@@ -225,11 +194,23 @@ export function makeEvmRpc(opts: EvmRpcOptions): AddressPlugin {
 
       // Emit update events for all affected subscribed addresses
       for (const originalAddress of addressesToUpdate) {
+        logger.info({
+          addr: getAddressPrefix(originalAddress),
+          msg: 'tx detected'
+        })
         emit('update', {
           address: originalAddress,
           checkpoint: block.number.toString()
         })
       }
+      logger.info({
+        blockNum: block.number.toString(),
+        msg: 'block processed',
+        internal: opts.includeInternal !== false,
+        traceBlock,
+        numSubs: subscribedAddresses.size,
+        numUpdates: addressesToUpdate.size
+      })
     }
   })
 
@@ -274,16 +255,4 @@ function getScanAdapter(
     case 'etherscan-v2':
       return makeEtherscanV2ScanAdapter(scanAdapterConfig, logger)
   }
-}
-
-/**
- * Sanitizes a URL for safe logging by removing sensitive information like API keys.
- * TODO: Implement URL sanitization once API keys are used for RPC URLs.
- *
- * @param url - The URL to sanitize
- * @returns A sanitized URL safe for logging
- */
-function sanitizeUrlForLogging(url: string): string {
-  // TODO: We'll clean URLs once API keys are used for RPC URLs
-  return url
 }

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -20,7 +20,6 @@ const asServerConfig = asObject({
   publicUri: asOptional(asString, 'https://address1.edge.app'),
 
   // Resources:
-  nowNodesApiKey: asOptional(asString, ''),
   serviceKeys: asOptional(asServiceKeys, () => ({
     '<service-host>': ['<api-key>']
   }))

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -1,6 +1,8 @@
 import { makeConfig } from 'cleaner-config'
-import { asArray, asNumber, asObject, asOptional, asString } from 'cleaners'
+import { asNumber, asObject, asOptional, asString } from 'cleaners'
 import { cpus } from 'os'
+
+import { asServiceKeys } from './util/serviceKeys'
 
 /**
  * Configures the server process as a whole,
@@ -19,12 +21,9 @@ const asServerConfig = asObject({
 
   // Resources:
   nowNodesApiKey: asOptional(asString, ''),
-  serviceKeys: asOptional(
-    asObject<string[] | undefined>(asArray(asString)),
-    () => ({
-      '<service-host>': ['<api-key>']
-    })
-  )
+  serviceKeys: asOptional(asServiceKeys, () => ({
+    '<service-host>': ['<api-key>']
+  }))
 })
 
 export const serverConfig = makeConfig(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,0 @@
-export interface Logger {
-  log: (...args: unknown[]) => void
-  error: (...args: unknown[]) => void
-  warn: (...args: unknown[]) => void
-}

--- a/src/util/addressUtils.ts
+++ b/src/util/addressUtils.ts
@@ -1,0 +1,3 @@
+export function getAddressPrefix(address: string): string {
+  return address.slice(0, 6)
+}

--- a/src/util/authenticateUrl.ts
+++ b/src/util/authenticateUrl.ts
@@ -1,0 +1,14 @@
+import { serverConfig } from '../serverConfig'
+import { pickRandom } from './pickRandom'
+import { replaceUrlParams } from './replaceUrlParams'
+import { serviceKeysFromUrl } from './serviceKeys'
+
+export function authenticateUrl(
+  url: string,
+  keyName: string = 'apiKey'
+): string {
+  const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
+  const apiKey = pickRandom(apiKeys) ?? ''
+  const authenticatedUrl = replaceUrlParams(url, { [keyName]: apiKey })
+  return authenticatedUrl
+}

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,0 +1,39 @@
+import pino from 'pino'
+
+export type Logger = pino.Logger
+
+// Single base logger instance
+export const logger = pino({
+  enabled: process.env.NODE_ENV !== 'test',
+  timestamp: pino.stdTimeFunctions.isoTime,
+  formatters: {
+    log(object) {
+      const { time, scope, ...rest } = object
+      return {
+        ...rest,
+        ...(time != null
+          ? { "Warning: 'time' field because it's reserved for Pino": time }
+          : {}),
+        ...(scope != null
+          ? {
+              "Warning: 'scope' field because it's reserved for logging context": scope
+            }
+          : {})
+      }
+    }
+  }
+})
+
+/**
+ * Creates a scoped logger using Pino's .child() pattern.
+ * Adds a "scope" field to identify the logging context (e.g., "blockbook", "evmRpc", "socket").
+ *
+ * @param scope - The scope identifier
+ * @param chainPluginId - Optional chain plugin ID (e.g., "ethereum", "arbitrum")
+ */
+export function makeLogger(scope: string, chainPluginId?: string): Logger {
+  return logger.child({
+    scope,
+    ...(chainPluginId != null ? { chainPluginId } : {})
+  })
+}

--- a/src/util/pickRandom.ts
+++ b/src/util/pickRandom.ts
@@ -4,6 +4,6 @@
  * @param arr - The array to pick from.
  * @returns A random element from the array.
  */
-export function pickRandom<T>(arr: T[]): T {
+export function pickRandom<T>(arr: T[]): T | undefined {
   return arr[Math.floor(Math.random() * arr.length)]
 }

--- a/src/util/replaceUrlParams.ts
+++ b/src/util/replaceUrlParams.ts
@@ -1,0 +1,15 @@
+/**
+ * Replaces {{paramName}} placeholders in a URL with supplied params.
+ * Returns the URL unchanged if no placeholders are found or params are not
+ * provided.
+ */
+export function replaceUrlParams(
+  url: string,
+  params: Record<string, string>
+): string {
+  let result = url
+  for (const [key, value] of Object.entries(params)) {
+    result = result.replace(`{{${key}}}`, value)
+  }
+  return result
+}

--- a/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
@@ -37,7 +37,7 @@ export function makeEtherscanV1ScanAdapter(
     const url = pickRandom(urls)
     if (url == null) {
       logger.error('No URLs for EtherscanV1ScanAdapter provided')
-      return false
+      return true
     }
     const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
     const apiKey = pickRandom(apiKeys)

--- a/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
@@ -36,7 +36,7 @@ export function makeEtherscanV1ScanAdapter(
     // Use a random API URL:
     const url = pickRandom(urls)
     if (url == null) {
-      logger.error({ msg: 'No URLs for EtherscanV1ScanAdapter provided' })
+      logger.error('No URLs for EtherscanV1ScanAdapter provided')
       return false
     }
     const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
@@ -44,17 +44,19 @@ export function makeEtherscanV1ScanAdapter(
     if (apiKey != null) {
       params.set('apikey', apiKey)
     } else {
-      logger.warn({ url, msg: 'No API key found, proceeding without one' })
+      logger.warn({ url }, 'No API key found, proceeding without one')
     }
     const response = await fetch(`${url}/api?${params.toString()}`)
     if (response.status !== 200) {
       const text = await response.text().catch(() => '')
-      logger.error({
-        status: response.status,
-        statusText: response.statusText,
-        responseText: text,
-        msg: 'scanAddress error'
-      })
+      logger.error(
+        {
+          status: response.status,
+          statusText: response.statusText,
+          responseText: text
+        },
+        'scanAddress error'
+      )
       return true
     }
     const dataRaw = await response.json()
@@ -77,11 +79,13 @@ export function makeEtherscanV1ScanAdapter(
     }
     const tokenResponse = await fetch(`${url}/api?${tokenParams.toString()}`)
     if (tokenResponse.status !== 200) {
-      logger.error({
-        status: tokenResponse.status,
-        statusText: tokenResponse.statusText,
-        msg: 'scanAddress tokenTx error'
-      })
+      logger.error(
+        {
+          status: tokenResponse.status,
+          statusText: tokenResponse.statusText
+        },
+        'scanAddress tokenTx error'
+      )
       return false
     }
     const tokenDataRaw = await tokenResponse.json()

--- a/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
@@ -1,7 +1,7 @@
 import { asArray, asObject, asString, asUnknown } from 'cleaners'
 
 import { serverConfig } from '../../serverConfig'
-import { Logger } from '../../types'
+import { Logger } from '../logger'
 import { pickRandom } from '../pickRandom'
 import { ScanAdapter } from './scanAdapterTypes'
 
@@ -37,7 +37,7 @@ export function makeEtherscanV1ScanAdapter(
     const host = new URL(url).host
     const apiKeys = serverConfig.serviceKeys[host]
     if (apiKeys == null) {
-      logger.warn('No API key found for', host)
+      logger.warn({ host, msg: 'No API key found' })
     }
     // Use a random API key:
     const apiKey = apiKeys == null ? undefined : pickRandom(apiKeys)
@@ -46,7 +46,13 @@ export function makeEtherscanV1ScanAdapter(
     }
     const response = await fetch(`${url}/api?${params.toString()}`)
     if (response.status !== 200) {
-      logger.error('scanAddress error', response.status, response.statusText)
+      const text = await response.text().catch(() => '')
+      logger.error({
+        status: response.status,
+        statusText: response.statusText,
+        responseText: text,
+        msg: 'scanAddress error'
+      })
       return true
     }
     const dataRaw = await response.json()
@@ -69,11 +75,11 @@ export function makeEtherscanV1ScanAdapter(
     }
     const tokenResponse = await fetch(`${url}/api?${tokenParams.toString()}`)
     if (tokenResponse.status !== 200) {
-      logger.error(
-        'scanAddress tokenTx error',
-        tokenResponse.status,
-        tokenResponse.statusText
-      )
+      logger.error({
+        status: tokenResponse.status,
+        statusText: tokenResponse.statusText,
+        msg: 'scanAddress tokenTx error'
+      })
       return false
     }
     const tokenDataRaw = await tokenResponse.json()

--- a/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV1ScanAdapter.ts
@@ -3,6 +3,7 @@ import { asArray, asObject, asString, asUnknown } from 'cleaners'
 import { serverConfig } from '../../serverConfig'
 import { Logger } from '../logger'
 import { pickRandom } from '../pickRandom'
+import { serviceKeysFromUrl } from '../serviceKeys'
 import { ScanAdapter } from './scanAdapterTypes'
 
 export interface EtherscanV1ScanAdapterConfig {
@@ -34,15 +35,16 @@ export function makeEtherscanV1ScanAdapter(
     })
     // Use a random API URL:
     const url = pickRandom(urls)
-    const host = new URL(url).host
-    const apiKeys = serverConfig.serviceKeys[host]
-    if (apiKeys == null) {
-      logger.warn({ host, msg: 'No API key found' })
+    if (url == null) {
+      logger.error({ msg: 'No URLs for EtherscanV1ScanAdapter provided' })
+      return false
     }
-    // Use a random API key:
-    const apiKey = apiKeys == null ? undefined : pickRandom(apiKeys)
+    const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
+    const apiKey = pickRandom(apiKeys)
     if (apiKey != null) {
       params.set('apikey', apiKey)
+    } else {
+      logger.warn({ url, msg: 'No API key found, proceeding without one' })
     }
     const response = await fetch(`${url}/api?${params.toString()}`)
     if (response.status !== 200) {

--- a/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
@@ -39,7 +39,7 @@ export function makeEtherscanV2ScanAdapter(
     const url = pickRandom(urls)
     if (url == null) {
       logger.error('No URLs for EtherscanV2ScanAdapter provided')
-      return false
+      return true
     }
     const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
     const apiKey = pickRandom(apiKeys)

--- a/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
@@ -38,7 +38,7 @@ export function makeEtherscanV2ScanAdapter(
     // Use a random API URL:
     const url = pickRandom(urls)
     if (url == null) {
-      logger.error({ msg: 'No URLs for EtherscanV2ScanAdapter provided' })
+      logger.error('No URLs for EtherscanV2ScanAdapter provided')
       return false
     }
     const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, url)
@@ -46,27 +46,28 @@ export function makeEtherscanV2ScanAdapter(
     if (apiKey != null) {
       params.set('apikey', apiKey)
     } else {
-      logger.warn({ url, msg: 'No API key found, proceeding without one' })
+      logger.warn({ url }, 'No API key found, proceeding without one')
     }
     const response = await fetchEtherscanV2(url, params)
     if ('error' in response) {
-      logger.error({
-        status: response.httpStatus,
-        statusText: response.httpStatusText,
-        responseText: response.responseText,
-        msg: 'scanAddress error'
-      })
+      logger.error(
+        {
+          status: response.httpStatus,
+          statusText: response.httpStatusText,
+          responseText: response.responseText
+        },
+        'scanAddress error'
+      )
       return true
     }
     let transactionData: ReturnType<typeof asResult>
     try {
       transactionData = asResult(response.json)
     } catch (error) {
-      logger.error({
-        err: error,
-        msg: 'scanAddress asResult cleaner error',
-        response: String(JSON.stringify(response.json))
-      })
+      logger.error(
+        { err: error, response: String(JSON.stringify(response.json)) },
+        'scanAddress asResult cleaner error'
+      )
       throw error
     }
     if (transactionData.status === '1' && transactionData.result.length > 0) {
@@ -88,11 +89,13 @@ export function makeEtherscanV2ScanAdapter(
     }
     const tokenResponse = await fetchEtherscanV2(url, tokenParams)
     if ('error' in tokenResponse) {
-      logger.error({
-        status: tokenResponse.httpStatus,
-        statusText: tokenResponse.httpStatusText,
-        msg: 'scanAddress tokenTx error'
-      })
+      logger.error(
+        {
+          status: tokenResponse.httpStatus,
+          statusText: tokenResponse.httpStatusText
+        },
+        'scanAddress tokenTx error'
+      )
       return false
     }
     const tokenData = asResult(tokenResponse.json)
@@ -115,22 +118,23 @@ export function makeEtherscanV2ScanAdapter(
     }
     const internalResponse = await fetchEtherscanV2(url, internalParams)
     if ('error' in internalResponse) {
-      logger.error({
-        status: internalResponse.httpStatus,
-        statusText: internalResponse.httpStatusText,
-        msg: 'scanAddress internalTx error'
-      })
+      logger.error(
+        {
+          status: internalResponse.httpStatus,
+          statusText: internalResponse.httpStatusText
+        },
+        'scanAddress internalTx error'
+      )
       return false
     }
     let internalData: ReturnType<typeof asResult>
     try {
       internalData = asResult(internalResponse.json)
     } catch (error) {
-      logger.error({
-        err: error,
-        msg: 'scanAddress asResult cleaner error',
-        response: String(JSON.stringify(internalResponse.json))
-      })
+      logger.error(
+        { err: error, response: String(JSON.stringify(internalResponse.json)) },
+        'scanAddress asResult cleaner error'
+      )
       throw error
     }
     if (internalData.status === '1' && internalData.result.length > 0) {

--- a/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
+++ b/src/util/scanAdapters/EtherscanV2ScanAdapter.ts
@@ -1,7 +1,7 @@
 import { asArray, asObject, asString, asUnknown } from 'cleaners'
 
 import { serverConfig } from '../../serverConfig'
-import { Logger } from '../../types'
+import { Logger } from '../logger'
 import { pickRandom } from '../pickRandom'
 import { ScanAdapter } from './scanAdapterTypes'
 
@@ -39,7 +39,7 @@ export function makeEtherscanV2ScanAdapter(
     const host = new URL(url).host
     const apiKeys = serverConfig.serviceKeys[host]
     if (apiKeys == null) {
-      logger.warn('No API key found for', host)
+      logger.warn({ host, msg: 'No API key found' })
     }
     // Use a random API key:
     const apiKey = apiKeys == null ? undefined : pickRandom(apiKeys)
@@ -48,14 +48,25 @@ export function makeEtherscanV2ScanAdapter(
     }
     const response = await fetchEtherscanV2(url, params)
     if ('error' in response) {
-      logger.error(
-        'scanAddress error',
-        response.httpStatus,
-        response.httpStatusText
-      )
+      logger.error({
+        status: response.httpStatus,
+        statusText: response.httpStatusText,
+        responseText: response.responseText,
+        msg: 'scanAddress error'
+      })
       return true
     }
-    const transactionData = asResult(response.json)
+    let transactionData: ReturnType<typeof asResult>
+    try {
+      transactionData = asResult(response.json)
+    } catch (error) {
+      logger.error({
+        err: error,
+        msg: 'scanAddress asResult cleaner error',
+        response: String(JSON.stringify(response.json))
+      })
+      throw error
+    }
     if (transactionData.status === '1' && transactionData.result.length > 0) {
       return true
     }
@@ -75,11 +86,11 @@ export function makeEtherscanV2ScanAdapter(
     }
     const tokenResponse = await fetchEtherscanV2(url, tokenParams)
     if ('error' in tokenResponse) {
-      logger.error(
-        'scanAddress tokenTx error',
-        tokenResponse.httpStatus,
-        tokenResponse.httpStatusText
-      )
+      logger.error({
+        status: tokenResponse.httpStatus,
+        statusText: tokenResponse.httpStatusText,
+        msg: 'scanAddress tokenTx error'
+      })
       return false
     }
     const tokenData = asResult(tokenResponse.json)
@@ -102,14 +113,24 @@ export function makeEtherscanV2ScanAdapter(
     }
     const internalResponse = await fetchEtherscanV2(url, internalParams)
     if ('error' in internalResponse) {
-      logger.error(
-        'scanAddress internalTx error',
-        internalResponse.httpStatus,
-        internalResponse.httpStatusText
-      )
+      logger.error({
+        status: internalResponse.httpStatus,
+        statusText: internalResponse.httpStatusText,
+        msg: 'scanAddress internalTx error'
+      })
       return false
     }
-    const internalData = asResult(internalResponse.json)
+    let internalData: ReturnType<typeof asResult>
+    try {
+      internalData = asResult(internalResponse.json)
+    } catch (error) {
+      logger.error({
+        err: error,
+        msg: 'scanAddress asResult cleaner error',
+        response: String(JSON.stringify(internalResponse.json))
+      })
+      throw error
+    }
     if (internalData.status === '1' && internalData.result.length > 0) {
       return true
     }
@@ -128,7 +149,12 @@ type EtherscanResult =
       json: unknown
       httpStatus: number
     }
-  | { error: boolean; httpStatus: number; httpStatusText: string }
+  | {
+      error: boolean
+      httpStatus: number
+      httpStatusText: string
+      responseText: string
+    }
 
 async function fetchEtherscanV2(
   url: string,
@@ -136,10 +162,12 @@ async function fetchEtherscanV2(
 ): Promise<EtherscanResult> {
   const response = await fetch(`${url}/v2/api?${params.toString()}`)
   if (response.status !== 200) {
+    const text = await response.text().catch(() => '')
     return {
       error: true,
       httpStatus: response.status,
-      httpStatusText: response.statusText
+      httpStatusText: response.statusText,
+      responseText: text
     }
   }
 

--- a/src/util/serviceKeys.ts
+++ b/src/util/serviceKeys.ts
@@ -1,0 +1,55 @@
+import { asArray, asObject, asString, Cleaner } from 'cleaners'
+
+/**
+ * The service keys map will map from a hostname to a list of API keys.
+ *
+ * For example, the service keys map might look like this:
+ *
+ * ```
+ * {
+ *   'api.example.com:443': ['key1', 'key2'],
+ *   'api.example.com': ['key3', 'key4'],
+ *   'example.com': ['key3', 'key4'],
+ * }
+ * ```
+ * More specific hostnames will take precedence over less specific ones (e.g.
+ * api.example.com:443 over api.example.com over example.com).
+ */
+export interface ServiceKeys {
+  [domain: string]: string[]
+}
+export const asServiceKeys: Cleaner<ServiceKeys> = asObject(asArray(asString))
+
+/**
+ * Returns a service key for the given URL by matching the host (with or
+ * without port) against the serviceKeys map. It checks subdomains as well.
+ * For example, "https://api.example.com:443" will first look for a
+ * key for "api.example.com:443", then "api.example.com", then
+ * "example.com:433". Returns a random key from the matching list if found.
+ */
+export function serviceKeysFromUrl(
+  serviceKeys: ServiceKeys,
+  url: string
+): string[] {
+  const urlObj = new URL(url)
+  const fullDomain = urlObj.hostname
+  const domainParts = fullDomain.split('.')
+  let apiKeys: string[] = []
+  // Try matching at each domain level, from most specific (full) to least
+  for (let i = 0; i <= domainParts.length - 2; i++) {
+    const domain = domainParts.slice(i).join('.')
+    const candidateWithPort =
+      urlObj.port !== '' ? `${domain}:${urlObj.port}` : domain
+    apiKeys = serviceKeys[candidateWithPort]
+    if (apiKeys == null) {
+      apiKeys = serviceKeys[domain]
+    }
+    if (apiKeys != null) {
+      break
+    }
+  }
+  if (apiKeys != null) {
+    return apiKeys
+  }
+  return []
+}

--- a/test/hub.test.ts
+++ b/test/hub.test.ts
@@ -68,8 +68,9 @@ describe('AddressHub', function () {
       host,
       port
     })
-    serverWs.on('connection', ws => {
-      hub.handleConnection(ws)
+    serverWs.on('connection', (ws, req) => {
+      const ip = req.socket.remoteAddress ?? 'unknown'
+      hub.handleConnection(ws, ip)
     })
   })
   afterAll(() => {

--- a/test/plugins/EtherscanV1ScanAdapter.test.ts
+++ b/test/plugins/EtherscanV1ScanAdapter.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals'
 
-import { Logger } from '../../src/types'
+import { Logger } from '../../src/util/logger'
 import { makeEtherscanV1ScanAdapter } from '../../src/util/scanAdapters/EtherscanV1ScanAdapter'
 import { mswServer } from '../util/mswServer'
 
@@ -14,11 +14,11 @@ describe('EtherscanV1ScanAdapter', function () {
   const TOKEN_TRANSACTION_HEIGHT = 22499360
 
   // Mock logger for testing
-  const logger: Logger = {
-    log: jest.fn(),
+  const logger = ({
+    info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn()
-  }
+  } as unknown) as Logger
 
   const adapter = makeEtherscanV1ScanAdapter(
     {

--- a/test/plugins/EtherscanV2ScanAdapter.test.ts
+++ b/test/plugins/EtherscanV2ScanAdapter.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals'
 
-import { Logger } from '../../src/types'
+import { Logger } from '../../src/util/logger'
 import { makeEtherscanV2ScanAdapter } from '../../src/util/scanAdapters/EtherscanV2ScanAdapter'
 import { mswServer } from '../util/mswServer'
 
@@ -15,11 +15,11 @@ describe('EtherscanV2ScanAdapter', function () {
   const TOKEN_TRANSACTION_HEIGHT = 22499360
 
   // Mock logger for testing
-  const logger: Logger = {
-    log: jest.fn(),
+  const logger = ({
+    info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn()
-  }
+  } as unknown) as Logger
 
   const adapter = makeEtherscanV2ScanAdapter(
     {

--- a/test/plugins/blockbook.test.ts
+++ b/test/plugins/blockbook.test.ts
@@ -12,9 +12,9 @@ import WebSocket from 'ws'
 
 import { messageToString } from '../../src/messageToString'
 import { makeBlockbook } from '../../src/plugins/blockbook'
-import { serverConfig } from '../../src/serverConfig'
 import { AddressPlugin } from '../../src/types/addressPlugin'
 import { blockbookProtocol } from '../../src/types/blockbookProtocol'
+import { authenticateUrl } from '../../src/util/authenticateUrl'
 
 // Enable this for debug testing against a real server. It may break some tests.
 const USE_REAL_BLOCKBOOK_SERVER = false
@@ -27,7 +27,7 @@ describe('blockbook plugin', function () {
   const host = 'localhost'
   const port = Math.floor(Math.random() * 1000 + 5000)
   const mockBlockbookUrl = USE_REAL_BLOCKBOOK_SERVER
-    ? `wss://btcbook.nownodes.io/wss/{nowNodesApiKey}`
+    ? authenticateUrl('wss://btcbook.nownodes.io/wss/{{apiKey}}')
     : `ws://${host}:${port}`
 
   const blockbookWsServer = new WebSocket.Server({
@@ -169,9 +169,7 @@ describe('blockbook plugin', function () {
   beforeEach(() => {
     plugin = makeBlockbook({
       pluginId: 'test',
-      url: mockBlockbookUrl,
-      // For testing real blockbook server, we need to provide the API key
-      nowNodesApiKey: serverConfig.nowNodesApiKey
+      url: mockBlockbookUrl
     })
   })
   afterEach(() => {

--- a/test/plugins/evmRpc.test.ts
+++ b/test/plugins/evmRpc.test.ts
@@ -83,12 +83,6 @@ describe('evmRpc plugin', function () {
 
   const mockUrl = 'https://ethereum.example.com/rpc'
 
-  const consoleSpy = {
-    log: jest.spyOn(console, 'log').mockImplementation(() => {}),
-    warn: jest.spyOn(console, 'warn').mockImplementation(() => {}),
-    error: jest.spyOn(console, 'error').mockImplementation(() => {})
-  }
-
   let plugin: AddressPlugin
 
   beforeAll(() => {
@@ -147,10 +141,6 @@ describe('evmRpc plugin', function () {
       })
     })
     expect(mockClient.watchBlocks).toHaveBeenCalled()
-    // Verify onResponse was set up (if transport exists)
-    if (mockClient.transport != null) {
-      expect(mockClient.transport.onResponse).toHaveBeenCalled()
-    }
   })
 
   test('subscribe should return true', async function () {
@@ -429,20 +419,11 @@ describe('evmRpc plugin', function () {
     expect(result).toBe(false)
   })
 
-  test('watchBlocks error handler should log errors', async function () {
+  test('watchBlocks error handler should handle errors gracefully', async function () {
     // Get the error handler that was passed to watchBlocks
     const errorHandler = mockClient.watchBlocks.mock.calls[0][0].onError
 
-    // Call the error handler
-    errorHandler(new Error('Test error'))
-
-    // Check that the error was logged
-    // The log prefix includes the plugin ID and URL (which is picked randomly from urls array)
-    expect(consoleSpy.error).toHaveBeenCalled()
-    const errorCall = consoleSpy.error.mock.calls[0]
-    expect(errorCall[0]).toContain('test-evm (')
-    expect(errorCall[0]).toContain(mockUrl)
-    expect(errorCall[1]).toBe('watchBlocks error')
-    expect(errorCall[2]).toBeInstanceOf(Error)
+    // Call the error handler - should not throw
+    expect(() => errorHandler(new Error('Test error'))).not.toThrow()
   })
 })

--- a/test/util/serviceKeys.test.ts
+++ b/test/util/serviceKeys.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  asServiceKeys,
+  ServiceKeys,
+  serviceKeysFromUrl
+} from '../../src/util/serviceKeys'
+
+describe('asServiceKeys', function () {
+  test('valid service keys object', function () {
+    const input = {
+      'api.example.com': ['key1', 'key2'],
+      'example.com': ['key3']
+    }
+    const result = asServiceKeys(input)
+    expect(result).toEqual(input)
+  })
+
+  test('empty object is valid', function () {
+    const input = {}
+    const result = asServiceKeys(input)
+    expect(result).toEqual({})
+  })
+
+  test('rejects non-string keys in array', function () {
+    const input = {
+      'api.example.com': ['key1', 123]
+    }
+    expect(() => asServiceKeys(input)).toThrow()
+  })
+
+  test('rejects non-array values', function () {
+    const input = {
+      'api.example.com': 'key1'
+    }
+    expect(() => asServiceKeys(input)).toThrow()
+  })
+})
+
+describe('serviceKeysFromUrl', function () {
+  describe('exact hostname matching', function () {
+    test('matches exact hostname', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1', 'key2']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual(['key1', 'key2'])
+    })
+
+    test('matches hostname with explicit port', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com:8080': ['portKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['portKey'])
+    })
+
+    test('prefers hostname with port over hostname without port', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com:8080': ['portKey'],
+        'api.example.com': ['noPortKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['portKey'])
+    })
+
+    test('falls back to hostname without port when port key not found', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['noPortKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['noPortKey'])
+    })
+  })
+
+  describe('subdomain matching', function () {
+    test('matches parent domain when subdomain not found', function () {
+      const serviceKeys: ServiceKeys = {
+        'example.com': ['parentKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual(['parentKey'])
+    })
+
+    test('prefers more specific subdomain over parent domain', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['subdomainKey'],
+        'example.com': ['parentKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual(['subdomainKey'])
+    })
+
+    test('matches deeply nested subdomains', function () {
+      const serviceKeys: ServiceKeys = {
+        'example.com': ['rootKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://deep.nested.api.example.com/path'
+      )
+      expect(result).toEqual(['rootKey'])
+    })
+
+    test('matches at correct subdomain level', function () {
+      const serviceKeys: ServiceKeys = {
+        'nested.api.example.com': ['nestedKey'],
+        'api.example.com': ['apiKey'],
+        'example.com': ['rootKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://deep.nested.api.example.com/path'
+      )
+      expect(result).toEqual(['nestedKey'])
+    })
+  })
+
+  describe('subdomain with port matching', function () {
+    test('matches parent domain with port', function () {
+      const serviceKeys: ServiceKeys = {
+        'example.com:8080': ['portKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['portKey'])
+    })
+
+    test('prefers subdomain with port over parent domain with port', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com:8080': ['subPortKey'],
+        'example.com:8080': ['parentPortKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['subPortKey'])
+    })
+
+    test('prefers subdomain with port over subdomain without port', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com:8080': ['subPortKey'],
+        'api.example.com': ['subKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:8080/path'
+      )
+      expect(result).toEqual(['subPortKey'])
+    })
+  })
+
+  describe('no match scenarios', function () {
+    test('returns empty array when no keys match', function () {
+      const serviceKeys: ServiceKeys = {
+        'other.com': ['otherKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual([])
+    })
+
+    test('returns empty array for empty service keys', function () {
+      const serviceKeys: ServiceKeys = {}
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual([])
+    })
+
+    test('does not match TLD only', function () {
+      const serviceKeys: ServiceKeys = {
+        com: ['tldKey']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path'
+      )
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('URL variations', function () {
+    test('works with http protocol', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'http://api.example.com/path'
+      )
+      expect(result).toEqual(['key1'])
+    })
+
+    test('works with query parameters', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path?foo=bar'
+      )
+      expect(result).toEqual(['key1'])
+    })
+
+    test('works with fragment', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1']
+      }
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com/path#section'
+      )
+      expect(result).toEqual(['key1'])
+    })
+
+    test('ignores default HTTPS port 443 (not included in URL.port)', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1']
+      }
+      // Standard port 443 is not included in URL.port property
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'https://api.example.com:443/path'
+      )
+      expect(result).toEqual(['key1'])
+    })
+
+    test('ignores default HTTP port 80 (not included in URL.port)', function () {
+      const serviceKeys: ServiceKeys = {
+        'api.example.com': ['key1']
+      }
+      // Standard port 80 is not included in URL.port property
+      const result = serviceKeysFromUrl(
+        serviceKeys,
+        'http://api.example.com:80/path'
+      )
+      expect(result).toEqual(['key1'])
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,6 +689,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.7.0.tgz#b139c81999c23e3c8d3c0a7234480e945920fc40"
   integrity sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==
 
+"@pinojs/redact@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"
+  integrity sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==
+
 "@scure/base@~1.2.2", "@scure/base@~1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
@@ -1082,6 +1087,11 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 axios@^1.7.4:
   version "1.8.4"
@@ -3471,6 +3481,11 @@ object.values@^1.1.1:
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
+on-exit-leak-free@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
+  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3732,6 +3747,35 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pino-abstract-transport@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz#b21e5f33a297e8c4c915c62b3ce5dd4a87a52c23"
+  integrity sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==
+  dependencies:
+    split2 "^4.0.0"
+
+pino-std-serializers@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz#a7b0cd65225f29e92540e7853bd73b07479893fc"
+  integrity sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==
+
+pino@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-10.2.0.tgz#01d7f0fdabdb7bb31102a55770b6fe2dd3f139e8"
+  integrity sha512-NFnZqUliT+OHkRXVSf8vdOr13N1wv31hRryVjqbreVh/SDCNaI6mnRDDq89HVRCbem1SAl7yj04OANeqP0nT6A==
+  dependencies:
+    "@pinojs/redact" "^0.4.0"
+    atomic-sleep "^1.0.0"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^3.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^5.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^4.0.0"
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -3790,6 +3834,11 @@ pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+process-warning@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-5.0.0.tgz#566e0bf79d1dff30a72d8bbbe9e8ecefe8d378d7"
+  integrity sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==
 
 progress@^2.0.0:
   version "2.0.3"
@@ -3859,6 +3908,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
 react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
@@ -3889,6 +3943,11 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
@@ -3987,6 +4046,11 @@ rxjs@^6.6.3:
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
+
+safe-stable-stringify@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -4158,6 +4222,13 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+sonic-boom@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
+  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
@@ -4196,6 +4267,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -4415,6 +4491,13 @@ thenify-all@^1.0.0:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+thread-stream@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-4.0.0.tgz#732f007c24da7084f729d6e3a7e3f5934a7380b7"
+  integrity sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==
+  dependencies:
+    real-require "^0.2.0"
 
 through@^2.3.8:
   version "2.3.8"


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes logging and configuration, expands transport support, and simplifies plugin coverage.
> 
> - **Logging**: Replace ad-hoc console logging with Pino (`src/util/logger.ts`), add scoped child loggers, and document usage/output (`docs/logging.md`). Refactor `hub`, `blockbook`, `evmRpc`, and `index` to emit structured JSON logs with connection/IP and plugin metadata.
> - **Service key templating**: Introduce `serviceKeys` cleaner/matcher and URL templating (`authenticateUrl`, `replaceUrlParams`, `serviceKeysFromUrl`) to inject API keys by host/subdomain; update scan adapters to pull keys per-URL.
> - **Transports**: Add WebSocket support to EVM RPC via `viem` (auto-select http/ws per URL); improve error handling and tracing; add address prefix helpers for concise logs.
> - **Plugins**: Use templated NowNodes URLs for Blockbook chains; reduce EVM plugin list to core networks (BSC, Botanix, Ethereum, Optimism, Polygon, zkSync) plus `fakePlugin`.
> - **Config/Tests**: Remove `nowNodesApiKey` in favor of `serviceKeys`; update `serverConfig`, Jest setup, and tests accordingly; add `pino` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b270b9f2b38a9a249f5d1cba8040193eccba416c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212754123530595