### PR TITLE
Alchemy Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Added flexible service key matching with URL templating.
+- added: Alchemy plugin for EVM networks and Solana.
 - changed: Migrated to JSON-based logs using Pino library.
 - changed: Use serviceKeys for nownodes API key.
 - removed: Removed plugins to reduce load: abstract, amoy, arbitrum, avalanche, base, bobevm, celo, ethereumclassic, ethereumpow, fantom, filecoinfevm, filecoinfevmcalibration, holesky, hyperevm, pulsechain, rsk, sepolia, sonic.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "*.html": "prettier --write"
   },
   "dependencies": {
-    "cleaner-config": "^0.1.7",
+    "cleaner-config": "^0.1.10",
     "cleaners": "^0.3.16",
     "clipanion": "^3.2.0-rc.3",
     "edge-server-tools": "^0.2.19",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cleaners": "^0.3.16",
     "clipanion": "^3.2.0-rc.3",
     "edge-server-tools": "^0.2.19",
+    "express": "^5.2.1",
     "node-fetch": "^2.6.0",
     "pino": "^10.2.0",
     "prom-client": "^15.1.0",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
+    "@types/express": "^5.0.6",
     "@types/node": "^20.8.5",
     "@types/node-fetch": "^2.5.3",
     "@types/ws": "^8.5.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,20 @@
 import cluster from 'cluster'
 import http from 'http'
 import { AggregatorRegistry } from 'prom-client'
-import WebSocket from 'ws'
 
-import { makeAddressHub } from './hub'
 import { serverConfig } from './serverConfig'
 import { makeLogger } from './util/logger'
 
-const logger = makeLogger('server')
+const logger = makeLogger('master-process')
 
 const aggregatorRegistry = new AggregatorRegistry()
 
 async function main(): Promise<void> {
   if (cluster.isPrimary) manageServers()
-  else await server()
+  else {
+    // Use dynamic import to avoid instantiating worker module state for primary process
+    await import('./worker')
+  }
 }
 
 function manageServers(): void {
@@ -48,54 +49,6 @@ function manageServers(): void {
   })
   httpServer.listen(metricsPort, metricsHost)
   logger.info({ port: metricsPort }, 'metrics server listening')
-}
-
-async function server(): Promise<void> {
-  const { allPlugins } = await import('./plugins/allPlugins')
-  const { listenPort, listenHost } = serverConfig
-
-  const wss = new WebSocket.Server({
-    port: listenPort,
-    host: listenHost
-  })
-  logger.info({ port: listenPort }, 'websocket server listening')
-
-  const hub = makeAddressHub({ plugins: allPlugins })
-  wss.on('connection', (ws, req) => {
-    // Extract IP from X-Forwarded-For header (if behind proxy) or socket
-    const forwardedFor = req.headers['x-forwarded-for']
-    const ip =
-      (typeof forwardedFor === 'string'
-        ? forwardedFor.split(',')[0].trim()
-        : undefined) ??
-      req.socket.remoteAddress ??
-      'unknown'
-    hub.handleConnection(ws, ip)
-  })
-
-  // Graceful shutdown handler
-  const shutdown = (): void => {
-    logger.info({ pid: process.pid }, 'shutting down')
-
-    // Stop accepting new connections
-    wss.close(() => {
-      logger.info({ pid: process.pid }, 'websocket server closed')
-    })
-
-    // Close all existing client connections
-    for (const client of wss.clients) {
-      client.close(1001, 'Server shutting down')
-    }
-
-    // Clean up plugin resources (timers, WebSocket connections, etc.)
-    hub.destroy()
-
-    logger.info({ pid: process.pid }, 'cleanup complete')
-    process.exit(0)
-  }
-
-  process.on('SIGTERM', shutdown)
-  process.on('SIGINT', shutdown)
 }
 
 main().catch(error => {

--- a/src/middleware/withWebhookRegistry.ts
+++ b/src/middleware/withWebhookRegistry.ts
@@ -1,0 +1,26 @@
+import { Serverlet } from 'serverlet'
+import { ExpressRequest } from 'serverlet/express'
+
+import { WebhookRegistry } from '../util/webhookRegistry'
+
+export interface WebhookRegistryRequest extends ExpressRequest {
+  webhookRegistry: WebhookRegistry
+}
+
+export interface WithWebhookRegistryOptions {
+  webhookRegistry: WebhookRegistry
+}
+
+/**
+ * Middleware that adds webhookRegistry to the request context
+ */
+export const withWebhookRegistry = <T>(opts: WithWebhookRegistryOptions) => (
+  serverlet: Serverlet<T & WebhookRegistryRequest>
+): Serverlet<T & ExpressRequest> => {
+  return request => {
+    return serverlet({
+      ...request,
+      webhookRegistry: opts.webhookRegistry
+    })
+  }
+}

--- a/src/plugins/alchemy.ts
+++ b/src/plugins/alchemy.ts
@@ -1,0 +1,628 @@
+import {
+  asArray,
+  asBoolean,
+  asEither,
+  asJSON,
+  asNull,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asValue
+} from 'cleaners'
+import crypto from 'crypto'
+import { makeEvents } from 'yavent'
+
+import { serverConfig } from '../serverConfig'
+import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import {
+  AlchemyNetwork,
+  AlchemyNotifyApi,
+  WebhookInfo
+} from '../util/alchemyNotifyApi'
+import { Logger, makeLogger } from '../util/logger'
+import { SigningKeyStore } from '../util/signingKeyStore'
+import { WebhookRegistry, WebhookRoute } from '../util/webhookRegistry'
+
+// Module-level cached promise (shared across all makeAlchemy instances).
+// Reset to undefined on failure so retries can create a fresh promise.
+let teamWebhooksPromise: Promise<WebhookInfo[]> | undefined
+
+export interface AlchemyOptions {
+  pluginId: string
+  network: AlchemyNetwork
+  notifyApi: AlchemyNotifyApi
+  signingKeyStore: SigningKeyStore
+  webhookRegistry: WebhookRegistry
+  /** Normalize addresses for comparison. Defaults to identity (no normalization). */
+  normalizeAddress?: (address: string) => string
+}
+
+/**
+ * Creates an Alchemy Address Activity webhook plugin.
+ *
+ * This plugin uses Alchemy's webhook infrastructure to receive real-time
+ * notifications when tracked addresses have on-chain activity.
+ */
+export function makeAlchemy(opts: AlchemyOptions): AddressPlugin {
+  const {
+    pluginId,
+    network,
+    notifyApi,
+    signingKeyStore,
+    webhookRegistry,
+    normalizeAddress = addr => addr
+  } = opts
+
+  const WEBHOOK_KEY = `alchemy/${pluginId}`
+
+  const [on, emit] = makeEvents<PluginEvents>()
+
+  const logger: Logger = makeLogger('alchemy', pluginId)
+
+  // Track subscribed addresses (normalized address -> original address)
+  const subscribedAddresses = new Map<string, string>()
+
+  // Webhook ID for this network (discovered or created on first subscription)
+  let webhookId: string | null = null
+
+  // Whether we've initialized (checked for existing webhooks)
+  let initialized = false
+  let initializingPromise: Promise<void> | null = null
+
+  // Pending address changes to batch
+  let pendingAddressesToAdd: string[] = []
+  let pendingAddressesToRemove: string[] = []
+  let batchTimeout: ReturnType<typeof setTimeout> | null = null
+
+  // Batch delay in milliseconds (debounce address updates)
+  const BATCH_DELAY_MS = 1000
+  const MAX_RETRY_DELAY_MS = 60_000
+
+  let destroyed = false
+  let processing = false
+  let retryCount = 0
+
+  /**
+   * Initialize the plugin by discovering existing webhooks.
+   * Deletes paused webhooks and reuses active ones.
+   */
+  async function initialize(): Promise<void> {
+    if (initialized) return
+    if (initializingPromise != null) return await initializingPromise
+
+    initializingPromise = doInitialize()
+    await initializingPromise
+    initializingPromise = null
+  }
+
+  async function doInitialize(): Promise<void> {
+    logger.info({ msg: 'Discovering existing webhooks' })
+
+    // Create or reuse shared promise for team webhooks
+    if (teamWebhooksPromise == null) {
+      teamWebhooksPromise = notifyApi.getTeamWebhooks()
+    }
+
+    try {
+      const webhooks = await teamWebhooksPromise
+      const expectedUrl = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
+
+      // Find webhooks for this network
+      const networkWebhooks = webhooks.filter(
+        (w: WebhookInfo) =>
+          w.network === network && w.webhook_type === 'ADDRESS_ACTIVITY'
+      )
+
+      for (const webhook of networkWebhooks) {
+        if (!webhook.is_active) {
+          // Delete paused webhooks
+          logger.info({
+            webhookId: webhook.id,
+            msg: 'Deleting paused webhook'
+          })
+          try {
+            await notifyApi.deleteWebhook(webhook.id)
+          } catch (err) {
+            logger.warn({
+              err,
+              webhookId: webhook.id,
+              msg: 'Failed to delete paused webhook'
+            })
+          }
+        } else if (webhookId == null) {
+          // Reuse first active webhook
+          webhookId = webhook.id
+          signingKeyStore.setSigningKey(webhook.id, webhook.signing_key)
+
+          // Update URL if different
+          if (webhook.webhook_url !== expectedUrl) {
+            logger.info({
+              webhookId: webhook.id,
+              oldUrl: webhook.webhook_url,
+              newUrl: expectedUrl,
+              msg: 'Updating webhook URL'
+            })
+            try {
+              await notifyApi.updateWebhook({
+                webhookId: webhook.id,
+                webhookUrl: expectedUrl
+              })
+            } catch (err) {
+              logger.error({
+                err,
+                webhookId: webhook.id,
+                msg: 'Failed to update webhook URL'
+              })
+            }
+          }
+
+          logger.info({
+            webhookId: webhook.id,
+            msg: 'Reusing existing webhook'
+          })
+        } else {
+          // Delete extra active webhooks (we only need one per network)
+          logger.info({
+            webhookId: webhook.id,
+            msg: 'Deleting extra webhook'
+          })
+          try {
+            await notifyApi.deleteWebhook(webhook.id)
+          } catch (err) {
+            logger.warn({
+              err,
+              webhookId: webhook.id,
+              msg: 'Failed to delete extra webhook'
+            })
+          }
+        }
+      }
+
+      initialized = true
+      logger.info({
+        webhookId,
+        msg: 'Webhook discovery complete'
+      })
+    } catch (err: unknown) {
+      // Reset promise on failure so next retry creates a fresh one
+      teamWebhooksPromise = undefined
+      logger.error({ err, msg: 'Failed to discover webhooks' })
+      throw err
+    }
+  }
+
+  /**
+   * Handle incoming activity from the webhook
+   */
+  function handleActivity(activities: AlchemyActivity[]): void {
+    // Track which subscribed addresses have updates
+    const addressesToUpdate = new Set<string>()
+
+    for (const activity of activities) {
+      const normalizedFrom = normalizeAddress(activity.fromAddress)
+      const normalizedTo = normalizeAddress(activity.toAddress)
+
+      // Check if fromAddress is subscribed
+      const originalFrom = subscribedAddresses.get(normalizedFrom)
+      if (originalFrom != null) {
+        addressesToUpdate.add(originalFrom)
+      }
+
+      // Check if toAddress is subscribed
+      const originalTo = subscribedAddresses.get(normalizedTo)
+      if (originalTo != null) {
+        addressesToUpdate.add(originalTo)
+      }
+    }
+
+    // Derive checkpoint from the highest block number across activities
+    let maxBlock = -1
+    for (const activity of activities) {
+      const n = parseInt(activity.blockNum, 16)
+      if (!Number.isNaN(n) && n > maxBlock) maxBlock = n
+    }
+    const checkpoint = maxBlock >= 0 ? maxBlock.toString() : undefined
+
+    for (const address of addressesToUpdate) {
+      emit('update', { address, checkpoint })
+    }
+  }
+
+  /**
+   * Process batched address changes
+   */
+  async function processBatchedChanges(): Promise<void> {
+    batchTimeout = null
+    if (destroyed || processing) {
+      if (processing) scheduleBatch()
+      return
+    }
+    processing = true
+
+    const toAdd = pendingAddressesToAdd
+    const toRemove = pendingAddressesToRemove
+    pendingAddressesToAdd = []
+    pendingAddressesToRemove = []
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      processing = false
+      return
+    }
+
+    try {
+      await initialize()
+
+      if (webhookId == null && toAdd.length > 0) {
+        const webhookUrl = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
+        logger.info({ network, msg: 'Creating webhook' })
+
+        const response = await notifyApi.createWebhook({
+          network,
+          webhookUrl,
+          addresses: [...toAdd]
+        })
+
+        webhookId = response.data.id
+        signingKeyStore.setSigningKey(webhookId, response.data.signing_key)
+        logger.info({ webhookId, msg: 'Created webhook' })
+
+        toAdd.length = 0
+      }
+
+      if (webhookId != null && (toAdd.length > 0 || toRemove.length > 0)) {
+        logger.info({
+          added: toAdd.length,
+          removed: toRemove.length,
+          msg: 'Updating addresses'
+        })
+
+        await notifyApi.updateWebhookAddresses({
+          webhookId,
+          addressesToAdd: toAdd.length > 0 ? toAdd : undefined,
+          addressesToRemove: toRemove.length > 0 ? toRemove : undefined
+        })
+      }
+
+      if (webhookId != null && subscribedAddresses.size === 0) {
+        logger.info({ webhookId, msg: 'Deleting webhook (no subscriptions)' })
+        try {
+          await notifyApi.deleteWebhook(webhookId)
+          webhookId = null
+        } catch (err) {
+          logger.warn({ err, msg: 'Failed to delete empty webhook' })
+        }
+      }
+
+      retryCount = 0
+    } catch (err: unknown) {
+      logger.error({ err, msg: 'Failed to update webhook addresses' })
+
+      if (!destroyed) {
+        pendingAddressesToAdd.push(...toAdd)
+        pendingAddressesToRemove.push(...toRemove)
+
+        retryCount++
+        const delay = Math.min(
+          BATCH_DELAY_MS * Math.pow(2, retryCount),
+          MAX_RETRY_DELAY_MS
+        )
+        scheduleBatch(delay)
+      }
+    } finally {
+      processing = false
+    }
+  }
+
+  /**
+   * Schedule a deferred batch update to sync pending address subscribe/
+   * unsubscribe changes with the Alchemy webhook API. Calls are debounced
+   * so that rapid successive subscribe/unsubscribe calls are coalesced
+   * into a single API request after the given delay.
+   */
+  function scheduleBatch(delay: number = BATCH_DELAY_MS): void {
+    // If a longer delay is requested (backoff), cancel existing shorter timeout
+    if (batchTimeout != null && delay > BATCH_DELAY_MS) {
+      clearTimeout(batchTimeout)
+      batchTimeout = null
+    }
+    if (batchTimeout == null) {
+      batchTimeout = setTimeout(() => {
+        processBatchedChanges().catch((err: unknown) => {
+          logger.error({ err, msg: 'Batch processing error' })
+        })
+      }, delay)
+    }
+  }
+
+  // Broadcast webhook activity to other cluster workers via IPC so
+  // every worker can match incoming activity against its own
+  // subscribedAddresses map (fixes round-robin webhook delivery).
+  function handleActivityAndBroadcast(activities: AlchemyActivity[]): void {
+    handleActivity(activities)
+    if (typeof process.send === 'function') {
+      process.send({
+        type: 'webhook-activity',
+        pluginId,
+        activities
+      })
+    }
+  }
+
+  // Listen for activity broadcasts relayed from other workers
+  const ipcHandler = (message: unknown): void => {
+    if (
+      message != null &&
+      typeof message === 'object' &&
+      (message as { type?: string }).type === 'webhook-activity' &&
+      (message as { pluginId?: string }).pluginId === pluginId
+    ) {
+      handleActivity((message as { activities: AlchemyActivity[] }).activities)
+    }
+  }
+  process.on('message', ipcHandler)
+
+  const webhookRoute = makeWebhookRoute(
+    logger,
+    network,
+    signingKeyStore,
+    handleActivityAndBroadcast
+  )
+
+  // Register this plugin's handler with the webhook registry
+  webhookRegistry.registerHandler(WEBHOOK_KEY, webhookRoute)
+
+  // Initialize immediately on plugin creation (cleanup paused webhooks, discover existing)
+  initialize().catch((err: unknown) => {
+    logger.error({ err, msg: 'Failed to initialize on startup' })
+  })
+
+  const plugin: AddressPlugin = {
+    pluginId,
+    on,
+
+    async subscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+
+      if (subscribedAddresses.has(normalized)) {
+        return true
+      }
+
+      subscribedAddresses.set(normalized, address)
+
+      pendingAddressesToAdd.push(normalized)
+
+      const removeIndex = pendingAddressesToRemove.indexOf(normalized)
+      if (removeIndex !== -1) {
+        pendingAddressesToRemove.splice(removeIndex, 1)
+      }
+
+      scheduleBatch()
+
+      return true
+    },
+
+    async unsubscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+
+      if (!subscribedAddresses.has(normalized)) {
+        return false
+      }
+
+      subscribedAddresses.delete(normalized)
+
+      pendingAddressesToRemove.push(normalized)
+
+      const addIndex = pendingAddressesToAdd.indexOf(normalized)
+      if (addIndex !== -1) {
+        pendingAddressesToAdd.splice(addIndex, 1)
+      }
+
+      scheduleBatch()
+
+      return true
+    },
+
+    // Note: scanAddress is not implemented for Alchemy webhooks
+    // The webhook model pushes updates, so scanning is not needed.
+    // If needed in future, could use Alchemy Transfers API.
+
+    destroy() {
+      destroyed = true
+
+      if (batchTimeout != null) {
+        clearTimeout(batchTimeout)
+        batchTimeout = null
+      }
+
+      process.removeListener('message', ipcHandler)
+      webhookRegistry.unregisterHandler(WEBHOOK_KEY, webhookRoute)
+
+      subscribedAddresses.clear()
+      pendingAddressesToAdd = []
+      pendingAddressesToRemove = []
+    }
+  }
+
+  return plugin
+}
+
+/**
+ * Validates the webhook signature using HMAC-SHA256
+ */
+function validateSignature(
+  rawBody: string,
+  signature: string,
+  signingKey: string
+): boolean {
+  const hmac = crypto.createHmac('sha256', signingKey)
+  hmac.update(rawBody, 'utf8')
+  const expectedSignature = hmac.digest('hex')
+
+  // Use timing-safe comparison to prevent timing attacks
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature)
+    )
+  } catch {
+    // Lengths don't match
+    return false
+  }
+}
+
+/**
+ * Handle incoming raw webhook from the registry.
+ * Parses and validates the Alchemy payload, then processes activity.
+ */
+const makeWebhookRoute = (
+  logger: Logger,
+  network: AlchemyNetwork,
+  signingKeyStore: SigningKeyStore,
+  handleActivity: (activities: AlchemyActivity[]) => void
+): WebhookRoute => async request => {
+  const rawBody: string =
+    typeof request.req.body === 'string' ? request.req.body : ''
+
+  // Parse the raw body into an Alchemy payload
+  let alchemyPayload: AlchemyWebhookPayload
+  try {
+    alchemyPayload = asAlchemyWebhookPayload(rawBody)
+  } catch (err: unknown) {
+    // Not a valid Alchemy payload; ignore
+    logger.warn({ err, rawBody, msg: 'Invalid payload' })
+    return {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Invalid payload'
+    }
+  }
+
+  // Authenticate before any authorization checks (network, type) to
+  // avoid leaking which network an endpoint serves to unauthenticated
+  // callers.
+  const signature = request.headers['x-alchemy-signature']
+  if (typeof signature !== 'string') {
+    logger.warn({ msg: 'Missing X-Alchemy-Signature header' })
+    return {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Missing signature'
+    }
+  }
+
+  const key = await signingKeyStore.getSigningKey(alchemyPayload.webhookId)
+  if (key == null) {
+    logger.error({
+      webhookId: alchemyPayload.webhookId,
+      msg: 'Unknown webhook ID'
+    })
+    return {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Unknown webhook'
+    }
+  }
+
+  if (!validateSignature(rawBody, signature, key)) {
+    logger.warn({
+      webhookId: alchemyPayload.webhookId,
+      msg: 'Invalid webhook signature'
+    })
+    return {
+      status: 401,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Invalid signature'
+    }
+  }
+
+  // Only handle webhooks for this plugin's network
+  if (alchemyPayload.event.network !== network)
+    return {
+      status: 400,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Network mismatch'
+    }
+
+  // Validate payload type
+  if (alchemyPayload.type !== 'ADDRESS_ACTIVITY') {
+    logger.warn({
+      type: alchemyPayload.type,
+      msg: 'Unexpected webhook type'
+    })
+    return {
+      status: 400,
+      headers: { 'content-type': 'text/plain' },
+      body: 'Unexpected webhook type'
+    }
+  }
+
+  // Process activity
+  handleActivity(alchemyPayload.event.activity)
+
+  return {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+    body: 'OK'
+  }
+}
+//
+// Cleaners & Types
+//
+
+const asAlchemyActivity = asObject({
+  blockNum: asString,
+  hash: asString,
+  fromAddress: asString,
+  toAddress: asString,
+  value: asNumber,
+  erc721TokenId: asOptional(asEither(asString, asNull)),
+  erc1155Metadata: asOptional(
+    asEither(asArray(asObject({ tokenId: asString, value: asString })), asNull)
+  ),
+  asset: asString,
+  category: asValue(
+    'external',
+    'internal',
+    'erc20',
+    'erc721',
+    'erc1155',
+    'token'
+  ),
+  rawContract: asObject({
+    rawValue: asString,
+    address: asOptional(asString),
+    decimals: asOptional(asNumber)
+  }),
+  typeTraceAddress: asOptional(asEither(asString, asNull)),
+  log: asOptional(
+    asObject({
+      address: asString,
+      topics: asArray(asString),
+      data: asString,
+      blockNumber: asString,
+      transactionHash: asString,
+      transactionIndex: asString,
+      blockHash: asString,
+      logIndex: asString,
+      removed: asBoolean
+    })
+  )
+})
+
+export type AlchemyActivity = ReturnType<typeof asAlchemyActivity>
+
+const asAlchemyWebhookPayload = asJSON(
+  asObject({
+    webhookId: asString,
+    id: asString,
+    createdAt: asString,
+    type: asString,
+    event: asObject({
+      network: asString,
+      activity: asArray(asAlchemyActivity)
+    })
+  })
+)
+
+type AlchemyWebhookPayload = ReturnType<typeof asAlchemyWebhookPayload>

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -1,29 +1,28 @@
-import { makeBlockbook } from './blockbook'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
 
 export const allPlugins = [
   // Bitcoin family:
-  makeBlockbook({
-    pluginId: 'bitcoin',
-    url: 'wss://btcbook.nownodes.io/wss/{{apiKey}}'
-  }),
-  makeBlockbook({
-    pluginId: 'bitcoincash',
-    url: 'wss://bchbook.nownodes.io/wss/{{apiKey}}'
-  }),
-  makeBlockbook({
-    pluginId: 'dogecoin',
-    url: 'wss://dogebook.nownodes.io/wss/{{apiKey}}'
-  }),
-  makeBlockbook({
-    pluginId: 'litecoin',
-    url: 'wss://ltcbook.nownodes.io/wss/{{apiKey}}'
-  }),
-  makeBlockbook({
-    pluginId: 'qtum',
-    url: 'wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}'
-  }),
+  // makeBlockbook({
+  //   pluginId: 'bitcoin',
+  //   url: 'wss://btcbook.nownodes.io/wss/{{apiKey}}'
+  // }),
+  // makeBlockbook({
+  //   pluginId: 'bitcoincash',
+  //   url: 'wss://bchbook.nownodes.io/wss/{{apiKey}}'
+  // }),
+  // makeBlockbook({
+  //   pluginId: 'dogecoin',
+  //   url: 'wss://dogebook.nownodes.io/wss/{{apiKey}}'
+  // }),
+  // makeBlockbook({
+  //   pluginId: 'litecoin',
+  //   url: 'wss://ltcbook.nownodes.io/wss/{{apiKey}}'
+  // }),
+  // makeBlockbook({
+  //   pluginId: 'qtum',
+  //   url: 'wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}'
+  // }),
 
   makeEvmRpc({
     pluginId: 'botanix',

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -42,6 +42,13 @@ export function makeAllPlugins(opts: AllPluginOptions): AddressPlugin[] {
 
     // EVM chains using EvmRpc polling (not supported by Alchemy):
     makeEvmRpc({
+      pluginId: 'bobevm',
+      urls: ['https://rpc.gobob.xyz'],
+      scanAdapters: [
+        { type: 'etherscan-v1', urls: ['https://explorer.gobob.xyz'] }
+      ]
+    }),
+    makeEvmRpc({
       pluginId: 'botanix',
       urls: ['https://rpc.ankr.com/botanix_mainnet'],
       scanAdapters: [
@@ -50,6 +57,67 @@ export function makeAllPlugins(opts: AllPluginOptions): AddressPlugin[] {
           urls: [
             'https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan'
           ]
+        }
+      ]
+    }),
+    makeEvmRpc({
+      pluginId: 'ethereumclassic',
+      urls: [
+        'https://0xrpc.io/etc',
+        'https://etc.rivet.link',
+        'https://ethereum-classic-mainnet.gateway.tatum.io'
+      ],
+      scanAdapters: [
+        { type: 'etherscan-v1', urls: ['https://etc.blockscout.com'] }
+      ]
+    }),
+    makeEvmRpc({
+      pluginId: 'ethereumpow',
+      urls: ['https://mainnet.ethereumpow.org'],
+      scanAdapters: []
+    }),
+    makeEvmRpc({
+      pluginId: 'filecoinfevm',
+      urls: [
+        'https://filecoin.chainup.net/rpc/v1',
+        'https://rpc.ankr.com/filecoin'
+      ],
+      scanAdapters: []
+    }),
+    makeEvmRpc({
+      pluginId: 'hyperevm',
+      urls: ['https://rpc.hyperliquid.xyz/evm'],
+      scanAdapters: [
+        {
+          type: 'etherscan-v1',
+          urls: [
+            'https://api.routescan.io/v2/network/mainnet/evm/999/etherscan'
+          ]
+        }
+      ]
+    }),
+    makeEvmRpc({
+      pluginId: 'pulsechain',
+      urls: [
+        'https://pulsechain-rpc.publicnode.com',
+        'https://rpc.pulsechainrpc.com',
+        'https://rpc.pulsechainstats.com'
+      ],
+      scanAdapters: [
+        { type: 'etherscan-v1', urls: ['https://api.scan.pulsechain.com'] }
+      ]
+    }),
+    makeEvmRpc({
+      pluginId: 'telos',
+      urls: [
+        'https://rpc.telos.net',
+        'https://telos.drpc.org',
+        'https://mainnet.telos.net/evm'
+      ],
+      scanAdapters: [
+        {
+          type: 'etherscan-v1',
+          urls: ['https://api.teloscan.io']
         }
       ]
     }),

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -1,94 +1,174 @@
+import { AddressPlugin } from '../types/addressPlugin'
+import { AlchemyNotifyApi } from '../util/alchemyNotifyApi'
+import { SigningKeyStore } from '../util/signingKeyStore'
+import { WebhookRegistry } from '../util/webhookRegistry'
+import { makeAlchemy } from './alchemy'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
 
-export const allPlugins = [
-  // Bitcoin family:
-  // makeBlockbook({
-  //   pluginId: 'bitcoin',
-  //   url: 'wss://btcbook.nownodes.io/wss/{{apiKey}}'
-  // }),
-  // makeBlockbook({
-  //   pluginId: 'bitcoincash',
-  //   url: 'wss://bchbook.nownodes.io/wss/{{apiKey}}'
-  // }),
-  // makeBlockbook({
-  //   pluginId: 'dogecoin',
-  //   url: 'wss://dogebook.nownodes.io/wss/{{apiKey}}'
-  // }),
-  // makeBlockbook({
-  //   pluginId: 'litecoin',
-  //   url: 'wss://ltcbook.nownodes.io/wss/{{apiKey}}'
-  // }),
-  // makeBlockbook({
-  //   pluginId: 'qtum',
-  //   url: 'wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}'
-  // }),
+interface AllPluginOptions {
+  notifyApi: AlchemyNotifyApi
+  signingKeyStore: SigningKeyStore
+  webhookRegistry: WebhookRegistry
+}
 
-  makeEvmRpc({
-    pluginId: 'botanix',
-    urls: ['https://rpc.ankr.com/botanix_mainnet'], // green privacy
-    scanAdapters: [
-      {
-        type: 'etherscan-v1',
-        urls: ['https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'ethereum',
-    urls: [
-      'https://mainnet.infura.io/v3/{{apiKey}}',
-      'https://lb.drpc.org/ogrpc?network=ethereum&dkey={{apiKey}}'
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 1,
-        urls: ['https://api.etherscan.io']
-      },
-      {
-        type: 'etherscan-v1',
-        urls: ['https://api.routescan.io/v2/network/mainnet/evm/1/etherscan']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'optimism',
-    urls: [
-      'https://lb.drpc.org/ogrpc?network=optimism&dkey={{apiKey}}'
-      // 'https://lb.drpc.live/optimism/{{apiKey}}'
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 10,
-        urls: ['https://api.etherscan.io']
-      },
-      {
-        type: 'etherscan-v1',
-        urls: ['https://api.routescan.io/v2/network/mainnet/evm/10/etherscan']
-      }
-    ]
-  }),
-  makeEvmRpc({
-    pluginId: 'zksync',
-    urls: [
-      'https://lb.drpc.org/ogrpc?network=zksync&dkey={{apiKey}}'
-      // 'https://lb.drpc.live/zksync/{{apiKey}}'
-    ],
-    scanAdapters: [
-      {
-        type: 'etherscan-v2',
-        chainId: 324,
-        urls: ['https://api.etherscan.io']
-      },
-      {
-        type: 'etherscan-v1',
-        urls: ['https://api.routescan.io/v2/network/mainnet/evm/324/etherscan']
-      }
-    ]
-  }),
+const evmNormalizeAddress = (addr: string): string => addr.toLowerCase()
 
-  // Testing:
-  makeFakePlugin()
-]
+export function makeAllPlugins(opts: AllPluginOptions): AddressPlugin[] {
+  const { notifyApi, signingKeyStore, webhookRegistry } = opts
+
+  return [
+    // Bitcoin family:
+    // makeBlockbook({
+    //   pluginId: 'bitcoin',
+    //   url: 'wss://btcbook.nownodes.io/wss/{{apiKey}}'
+    // }),
+    // makeBlockbook({
+    //   pluginId: 'bitcoincash',
+    //   url: 'wss://bchbook.nownodes.io/wss/{{apiKey}}'
+    // }),
+    // makeBlockbook({
+    //   pluginId: 'dogecoin',
+    //   url: 'wss://dogebook.nownodes.io/wss/{{apiKey}}'
+    // }),
+    // makeBlockbook({
+    //   pluginId: 'litecoin',
+    //   url: 'wss://ltcbook.nownodes.io/wss/{{apiKey}}'
+    // }),
+    // makeBlockbook({
+    //   pluginId: 'qtum',
+    //   url: 'wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}'
+    // }),
+
+    // EVM chains using EvmRpc polling (not supported by Alchemy):
+    makeEvmRpc({
+      pluginId: 'botanix',
+      urls: ['https://rpc.ankr.com/botanix_mainnet'],
+      scanAdapters: [
+        {
+          type: 'etherscan-v1',
+          urls: [
+            'https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan'
+          ]
+        }
+      ]
+    }),
+
+    // EVM chains using Alchemy Address Activity webhooks:
+    makeAlchemy({
+      pluginId: 'abstract',
+      network: 'ABSTRACT_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'arbitrum',
+      network: 'ARB_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'avalanche',
+      network: 'AVAX_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'base',
+      network: 'BASE_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'binancesmartchain',
+      network: 'BNB_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'celo',
+      network: 'CELO_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'ethereum',
+      network: 'ETH_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'fantom',
+      network: 'FANTOM_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'optimism',
+      network: 'OPT_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'polygon',
+      network: 'MATIC_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'rsk',
+      network: 'ROOTSTOCK_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'solana',
+      network: 'SOLANA_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry
+      // Solana uses base58 addresses (case-sensitive), no normalization needed
+    }),
+    makeAlchemy({
+      pluginId: 'sonic',
+      network: 'SONIC_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+    makeAlchemy({
+      pluginId: 'zksync',
+      network: 'ZKSYNC_MAINNET',
+      notifyApi,
+      signingKeyStore,
+      webhookRegistry,
+      normalizeAddress: evmNormalizeAddress
+    }),
+
+    // Testing:
+    makeFakePlugin()
+  ]
+}

--- a/src/routes/healthCheckRoute.ts
+++ b/src/routes/healthCheckRoute.ts
@@ -1,0 +1,12 @@
+import { Serverlet } from 'serverlet'
+import { ExpressRequest } from 'serverlet/express'
+
+/**
+ * Health check response for webhook URL validation.
+ * Alchemy sends GET/HEAD requests to verify webhook URLs are reachable.
+ */
+export const healthCheckRoute: Serverlet<ExpressRequest> = () => ({
+  status: 200,
+  headers: { 'content-type': 'text/plain' },
+  body: 'OK'
+})

--- a/src/routes/notFoundRoute.ts
+++ b/src/routes/notFoundRoute.ts
@@ -1,0 +1,8 @@
+import { Serverlet } from 'serverlet'
+import { ExpressRequest } from 'serverlet/express'
+
+export const notFoundRoute: Serverlet<ExpressRequest> = () => ({
+  status: 404,
+  headers: { 'content-type': 'text/plain' },
+  body: 'Not Found'
+})

--- a/src/routes/webhookRoute.ts
+++ b/src/routes/webhookRoute.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, Serverlet } from 'serverlet'
+
+import { WebhookRegistryRequest } from '../middleware/withWebhookRegistry'
+
+/**
+ * Generic webhook route that extracts the webhook key from the path
+ * and dispatches to all registered handlers for that key.
+ */
+export const webhookRoute: Serverlet<WebhookRegistryRequest> = async (
+  request
+): Promise<HttpResponse> => {
+  // Extract key from path: /webhook/alchemy → 'alchemy'
+  const webhookKey = request.path.replace(/^\/webhook\//, '')
+  return await request.webhookRegistry.handleWebhook(webhookKey, request)
+}

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -17,7 +17,12 @@ const asServerConfig = asObject({
   listenPort: asOptional(asNumber, 8008),
   metricsHost: asOptional(asString, '127.0.0.1'),
   metricsPort: asOptional(asNumber, 8009),
+  webhookHost: asOptional(asString, '127.0.0.1'),
+  webhookPort: asOptional(asNumber, 8010),
   publicUri: asOptional(asString, 'https://address1.edge.app'),
+
+  // Alchemy webhook:
+  alchemyAuthToken: asOptional(asString, ''),
 
   // Resources:
   serviceKeys: asOptional(asServiceKeys, () => ({

--- a/src/util/alchemyNotifyApi.ts
+++ b/src/util/alchemyNotifyApi.ts
@@ -1,0 +1,391 @@
+import {
+  asArray,
+  asBoolean,
+  asJSON,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  Cleaner
+} from 'cleaners'
+import fetch from 'node-fetch'
+
+import { serverConfig } from '../serverConfig'
+import { makeLogger } from './logger'
+
+export interface AlchemyNotifyApi {
+  createWebhook: (params: CreateWebhookParams) => Promise<CreateWebhookResponse>
+  updateWebhook: (params: UpdateWebhookParams) => Promise<void>
+  updateWebhookAddresses: (
+    params: UpdateWebhookAddressesParams
+  ) => Promise<void>
+  getWebhookAddresses: (
+    params: GetWebhookAddressesParams
+  ) => Promise<GetWebhookAddressesResponse>
+  getTeamWebhooks: () => Promise<WebhookInfo[]>
+  deleteWebhook: (webhookId: string) => Promise<void>
+}
+
+interface CreateWebhookParams {
+  network: AlchemyNetwork
+  webhookUrl: string
+  addresses?: string[]
+}
+
+interface UpdateWebhookAddressesParams {
+  webhookId: string
+  addressesToAdd?: string[]
+  addressesToRemove?: string[]
+}
+
+interface GetWebhookAddressesParams {
+  webhookId: string
+  limit?: number
+  after?: string
+}
+
+interface UpdateWebhookParams {
+  webhookId: string
+  webhookUrl?: string
+  isActive?: boolean
+}
+
+// Alchemy network identifiers
+// https://docs.alchemy.com/reference/create-webhook
+export type AlchemyNetwork =
+  // Ethereum
+  | 'ETH_MAINNET'
+  | 'ETH_SEPOLIA'
+  | 'ETH_HOLESKY'
+  | 'ETH_HOODI'
+  // Polygon
+  | 'MATIC_MAINNET'
+  | 'MATIC_AMOY'
+  // Polygon zkEVM
+  | 'POLYGONZKEVM_MAINNET'
+  | 'POLYGONZKEVM_CARDONA'
+  // Optimism
+  | 'OPT_MAINNET'
+  | 'OPT_SEPOLIA'
+  // Arbitrum
+  | 'ARB_MAINNET'
+  | 'ARB_SEPOLIA'
+  // Arbitrum Nova
+  | 'ARBNOVA_MAINNET'
+  // Astar
+  | 'ASTAR_MAINNET'
+  // Base
+  | 'BASE_MAINNET'
+  | 'BASE_SEPOLIA'
+  // zkSync
+  | 'ZKSYNC_MAINNET'
+  | 'ZKSYNC_SEPOLIA'
+  // Shape
+  | 'SHAPE_MAINNET'
+  | 'SHAPE_SEPOLIA'
+  // Linea
+  | 'LINEA_MAINNET'
+  | 'LINEA_SEPOLIA'
+  // Fantom
+  | 'FANTOM_MAINNET'
+  | 'FANTOM_TESTNET'
+  // ZetaChain
+  | 'ZETACHAIN_MAINNET'
+  | 'ZETACHAIN_TESTNET'
+  // Blast
+  | 'BLAST_MAINNET'
+  | 'BLAST_SEPOLIA'
+  // Mantle
+  | 'MANTLE_MAINNET'
+  | 'MANTLE_SEPOLIA'
+  // Scroll
+  | 'SCROLL_MAINNET'
+  | 'SCROLL_SEPOLIA'
+  // Gnosis
+  | 'GNOSIS_MAINNET'
+  | 'GNOSIS_CHIADO'
+  // BNB
+  | 'BNB_MAINNET'
+  | 'BNB_TESTNET'
+  // Avalanche
+  | 'AVAX_MAINNET'
+  | 'AVAX_FUJI'
+  // Celo
+  | 'CELO_MAINNET'
+  | 'CELO_ALFAJORES'
+  | 'CELO_BAKLAVA'
+  // Metis
+  | 'METIS_MAINNET'
+  // opBNB
+  | 'OPBNB_MAINNET'
+  | 'OPBNB_TESTNET'
+  // Berachain
+  | 'BERACHAIN_MAINNET'
+  | 'BERACHAIN_BEPOLIA'
+  // Soneium
+  | 'SONEIUM_MAINNET'
+  | 'SONEIUM_MINATO'
+  // WorldChain
+  | 'WORLDCHAIN_MAINNET'
+  | 'WORLDCHAIN_SEPOLIA'
+  // Rootstock
+  | 'ROOTSTOCK_MAINNET'
+  | 'ROOTSTOCK_TESTNET'
+  // Flow
+  | 'FLOW_MAINNET'
+  | 'FLOW_TESTNET'
+  // Zora
+  | 'ZORA_MAINNET'
+  | 'ZORA_SEPOLIA'
+  // Frax
+  | 'FRAX_MAINNET'
+  | 'FRAX_SEPOLIA'
+  // Polynomial
+  | 'POLYNOMIAL_MAINNET'
+  | 'POLYNOMIAL_SEPOLIA'
+  // CrossFi
+  | 'CROSSFI_MAINNET'
+  | 'CROSSFI_TESTNET'
+  // ApeChain
+  | 'APECHAIN_MAINNET'
+  | 'APECHAIN_CURTIS'
+  // Lens
+  | 'LENS_MAINNET'
+  | 'LENS_SEPOLIA'
+  // Geist
+  | 'GEIST_MAINNET'
+  | 'GEIST_POLTER'
+  // Lumia
+  | 'LUMIA_PRISM'
+  | 'LUMIA_TESTNET'
+  // Unichain
+  | 'UNICHAIN_MAINNET'
+  | 'UNICHAIN_SEPOLIA'
+  // Sonic
+  | 'SONIC_MAINNET'
+  | 'SONIC_BLAZE'
+  // Abstract
+  | 'ABSTRACT_MAINNET'
+  | 'ABSTRACT_TESTNET'
+  // Degen
+  | 'DEGEN_MAINNET'
+  // Ink
+  | 'INK_MAINNET'
+  | 'INK_SEPOLIA'
+  // Sei
+  | 'SEI_MAINNET'
+  | 'SEI_TESTNET'
+  // Ronin
+  | 'RONIN_MAINNET'
+  | 'RONIN_SAIGON'
+  // Solana
+  | 'SOLANA_MAINNET'
+  | 'SOLANA_DEVNET'
+  // Settlus
+  | 'SETTLUS_MAINNET'
+  | 'SETTLUS_SEPTESTNET'
+  // SuperSeed
+  | 'SUPERSEED_MAINNET'
+  | 'SUPERSEED_SEPOLIA'
+  // Anime
+  | 'ANIME_MAINNET'
+  | 'ANIME_SEPOLIA'
+  // Story
+  | 'STORY_MAINNET'
+  | 'STORY_AENEID'
+  // Testnet-only
+  | 'XMTP_TESTNET'
+  | 'MONAD_TESTNET'
+  | 'GENSYN_TESTNET'
+  | 'TEA_SEPOLIA'
+  | 'MEGAETH_TESTNET'
+
+const ALCHEMY_API_BASE = 'https://dashboard.alchemy.com/api'
+
+export function makeAlchemyNotifyApi(): AlchemyNotifyApi {
+  const logger = makeLogger('alchemy-notify-api')
+
+  function getAuthToken(): string {
+    const authToken = serverConfig.alchemyAuthToken
+    if (authToken === '') {
+      throw new Error('Missing alchemyAuthToken in config')
+    }
+    return authToken
+  }
+
+  async function apiRequestVoid(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    body?: object
+  ): Promise<void> {
+    await apiRequest(endpoint, method, body)
+  }
+
+  async function apiRequest<T = undefined>(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    body?: object,
+    asResponse?: Cleaner<T>
+  ): Promise<T> {
+    const authToken = getAuthToken()
+    const url = `${ALCHEMY_API_BASE}${endpoint}`
+
+    logger.info({ method, endpoint, msg: 'Alchemy API request' })
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Alchemy-Token': authToken
+      },
+      body: body != null ? JSON.stringify(body) : undefined
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(
+        `Alchemy API error: ${response.status} ${response.statusText} - ${errorText}`
+      )
+    }
+
+    if (asResponse == null) {
+      return undefined as T
+    }
+
+    const text = await response.text()
+    try {
+      return asResponse(text)
+    } catch (err: unknown) {
+      logger.error({
+        err,
+        responseText: text,
+        msg: 'Alchemy API cleaner error'
+      })
+      throw err
+    }
+  }
+
+  return {
+    async createWebhook(
+      params: CreateWebhookParams
+    ): Promise<CreateWebhookResponse> {
+      return await apiRequest(
+        '/create-webhook',
+        'POST',
+        {
+          network: params.network,
+          webhook_type: 'ADDRESS_ACTIVITY',
+          webhook_url: params.webhookUrl,
+          addresses: params.addresses ?? []
+        },
+        asCreateWebhookResponse
+      )
+    },
+
+    async updateWebhook(params: UpdateWebhookParams): Promise<void> {
+      const body: Record<string, unknown> = {
+        webhook_id: params.webhookId
+      }
+      if (params.webhookUrl != null) {
+        body.webhook_url = params.webhookUrl
+      }
+      if (params.isActive != null) {
+        body.is_active = params.isActive
+      }
+      await apiRequestVoid('/update-webhook', 'PUT', body)
+    },
+
+    async updateWebhookAddresses(
+      params: UpdateWebhookAddressesParams
+    ): Promise<void> {
+      await apiRequestVoid('/update-webhook-addresses', 'PATCH', {
+        webhook_id: params.webhookId,
+        addresses_to_add: params.addressesToAdd ?? [],
+        addresses_to_remove: params.addressesToRemove ?? []
+      })
+    },
+
+    async getWebhookAddresses(
+      params: GetWebhookAddressesParams
+    ): Promise<GetWebhookAddressesResponse> {
+      const queryParams = new URLSearchParams({
+        webhook_id: params.webhookId
+      })
+      if (params.limit != null) {
+        queryParams.set('limit', params.limit.toString())
+      }
+      if (params.after != null) {
+        queryParams.set('after', params.after)
+      }
+
+      return await apiRequest(
+        `/webhook-addresses?${queryParams.toString()}`,
+        'GET',
+        undefined,
+        asGetWebhookAddressesResponse
+      )
+    },
+
+    async getTeamWebhooks(): Promise<WebhookInfo[]> {
+      const response = await apiRequest(
+        '/team-webhooks',
+        'GET',
+        undefined,
+        asGetTeamWebhooksResponse
+      )
+      return response.data
+    },
+
+    async deleteWebhook(webhookId: string): Promise<void> {
+      await apiRequestVoid(`/delete-webhook?webhook_id=${webhookId}`, 'DELETE')
+    }
+  }
+}
+
+//
+// Cleaners & Types
+//
+
+const asWebhookInfo = asObject({
+  id: asString,
+  network: asString,
+  webhook_type: asString,
+  webhook_url: asString,
+  is_active: asBoolean,
+  time_created: asNumber,
+  signing_key: asString,
+  version: asString,
+  app_id: asOptional(asString)
+})
+
+export type WebhookInfo = ReturnType<typeof asWebhookInfo>
+
+const asCreateWebhookResponse = asJSON(
+  asObject({
+    data: asWebhookInfo
+  })
+)
+
+type CreateWebhookResponse = ReturnType<typeof asCreateWebhookResponse>
+
+const asGetWebhookAddressesResponse = asJSON(
+  asObject({
+    data: asArray(asString),
+    pagination: asObject({
+      cursors: asObject({
+        after: asOptional(asString)
+      }),
+      total_count: asNumber
+    })
+  })
+)
+
+type GetWebhookAddressesResponse = ReturnType<
+  typeof asGetWebhookAddressesResponse
+>
+
+const asGetTeamWebhooksResponse = asJSON(
+  asObject({
+    data: asArray(asWebhookInfo)
+  })
+)

--- a/src/util/signingKeyStore.ts
+++ b/src/util/signingKeyStore.ts
@@ -1,0 +1,94 @@
+import { AlchemyNotifyApi } from './alchemyNotifyApi'
+import { Logger, makeLogger } from './logger'
+
+export interface SigningKeyStore {
+  /** Store a signing key for a webhook */
+  setSigningKey: (webhookId: string, signingKey: string) => void
+
+  /** Get signing key for a webhook, recovering from API if not cached */
+  getSigningKey: (webhookId: string) => Promise<string | undefined>
+
+  /** Recover all signing keys from the Alchemy API */
+  recoverSigningKeys: () => Promise<void>
+}
+
+export interface SigningKeyStoreOptions {
+  notifyApi: AlchemyNotifyApi
+}
+
+/**
+ * Creates a store for webhook signing keys.
+ * Caches signing keys in memory and can recover them from the Alchemy API
+ * after server restarts.
+ */
+export function makeSigningKeyStore(
+  opts: SigningKeyStoreOptions
+): SigningKeyStore {
+  const { notifyApi } = opts
+  const logger: Logger = makeLogger('signing-key-store')
+
+  // In-memory cache: webhookId -> signingKey
+  const signingKeys = new Map<string, string>()
+
+  let hasRecovered = false
+  let recoveringPromise: Promise<void> | null = null
+
+  async function doRecover(): Promise<void> {
+    logger.info({ msg: 'Recovering signing keys from Alchemy API' })
+    const webhooks = await notifyApi.getTeamWebhooks()
+
+    for (const webhook of webhooks) {
+      signingKeys.set(webhook.id, webhook.signing_key)
+    }
+
+    hasRecovered = true
+    logger.info({
+      count: webhooks.length,
+      msg: 'Recovered signing keys'
+    })
+  }
+
+  return {
+    setSigningKey(webhookId: string, signingKey: string) {
+      signingKeys.set(webhookId, signingKey)
+      logger.info({ webhookId, msg: 'Stored signing key' })
+    },
+
+    async getSigningKey(webhookId: string): Promise<string | undefined> {
+      let signingKey = signingKeys.get(webhookId)
+      if (signingKey != null) {
+        return signingKey
+      }
+
+      if (!hasRecovered) {
+        logger.info({
+          webhookId,
+          msg: 'Signing key not cached, recovering from API'
+        })
+        try {
+          await this.recoverSigningKeys()
+        } catch {
+          // Recovery failed; return undefined so handler responds 401
+        }
+        signingKey = signingKeys.get(webhookId)
+      }
+
+      if (signingKey == null) {
+        logger.warn({ webhookId, msg: 'Signing key not found' })
+      }
+
+      return signingKey
+    },
+
+    async recoverSigningKeys(): Promise<void> {
+      if (recoveringPromise != null) return await recoveringPromise
+
+      recoveringPromise = doRecover()
+      try {
+        await recoveringPromise
+      } finally {
+        recoveringPromise = null
+      }
+    }
+  }
+}

--- a/src/util/webhookRegistry.ts
+++ b/src/util/webhookRegistry.ts
@@ -1,0 +1,80 @@
+import { HttpResponse, Serverlet } from 'serverlet'
+import { ExpressRequest } from 'serverlet/express'
+
+import { makeLogger } from './logger'
+
+export type WebhookRoute = Serverlet<ExpressRequest>
+
+export interface WebhookRegistry {
+  /** Register a handler for a webhook key */
+  registerHandler: (webhookKey: string, routeHandler: WebhookRoute) => void
+
+  /** Unregister a handler for a webhook key */
+  unregisterHandler: (webhookKey: string, routeHandler: WebhookRoute) => void
+
+  /** Dispatch incoming webhook to handlers registered for the given key */
+  handleWebhook: (
+    webhookKey: string,
+    request: ExpressRequest
+  ) => HttpResponse | Promise<HttpResponse>
+}
+
+const OK_RESPONSE: HttpResponse = {
+  status: 200,
+  headers: { 'content-type': 'text/plain' },
+  body: 'OK'
+}
+
+/**
+ * Creates a registry for webhook handlers.
+ * Plugins register their handlers here, and the HTTP server routes
+ * incoming webhooks to the appropriate handlers by key.
+ */
+export function makeWebhookRegistry(): WebhookRegistry {
+  const logger = makeLogger('webhook-registry')
+  const routeHandlerMap = new Map<string, WebhookRoute[]>()
+
+  return {
+    registerHandler(webhookKey: string, routeHandler: WebhookRoute) {
+      const routeHandlers = routeHandlerMap.get(webhookKey) ?? []
+      routeHandlers.push(routeHandler)
+      routeHandlerMap.set(webhookKey, routeHandlers)
+      logger.info({ webhookKey, msg: 'Registered webhook route' })
+    },
+
+    unregisterHandler(webhookKey: string, routeHandler: WebhookRoute) {
+      const routeHandlers = routeHandlerMap.get(webhookKey)
+      if (routeHandlers == null) return
+      const index = routeHandlers.indexOf(routeHandler)
+      if (index !== -1) routeHandlers.splice(index, 1)
+      if (routeHandlers.length === 0) routeHandlerMap.delete(webhookKey)
+      logger.info({ webhookKey, msg: 'Unregistered webhook route' })
+    },
+
+    async handleWebhook(
+      webhookKey: string,
+      request: ExpressRequest
+    ): Promise<HttpResponse> {
+      const routeHandlers = routeHandlerMap.get(webhookKey)
+      if (routeHandlers == null) return OK_RESPONSE
+
+      for (const routeHandler of routeHandlers) {
+        try {
+          const response = await routeHandler(request)
+          const status = response.status ?? 200
+          if (status < 200 || status >= 300) {
+            return response
+          }
+        } catch (err: unknown) {
+          logger.error({ err, webhookKey, msg: 'Error in webhook route' })
+          return {
+            status: 500,
+            headers: { 'content-type': 'text/plain' },
+            body: 'Internal error'
+          }
+        }
+      }
+      return OK_RESPONSE
+    }
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,53 +1,105 @@
+import express, { Express } from 'express'
+import { pickMethod, pickPath } from 'serverlet'
+import { ExpressRequest, makeExpressRoute } from 'serverlet/express'
 import WebSocket from 'ws'
 
 import { makeAddressHub } from './hub'
-import { allPlugins } from './plugins/allPlugins'
+import { withWebhookRegistry } from './middleware/withWebhookRegistry'
+import { makeAllPlugins } from './plugins/allPlugins'
+import { healthCheckRoute } from './routes/healthCheckRoute'
+import { notFoundRoute } from './routes/notFoundRoute'
+import { webhookRoute } from './routes/webhookRoute'
 import { serverConfig } from './serverConfig'
-import { makeLogger } from './util/logger'
+import { AlchemyNotifyApi } from './util/alchemyNotifyApi'
+import { logger } from './util/logger'
+import { SigningKeyStore } from './util/signingKeyStore'
+import { WebhookRegistry } from './util/webhookRegistry'
 
-const logger = makeLogger('server')
-
-const { listenPort, listenHost } = serverConfig
-
-const wss = new WebSocket.Server({
-  port: listenPort,
-  host: listenHost
-})
-logger.info({ port: listenPort }, 'websocket server listening')
-
-const hub = makeAddressHub({ plugins: allPlugins })
-wss.on('connection', (ws, req) => {
-  // Extract IP from X-Forwarded-For header (if behind proxy) or socket
-  const forwardedFor = req.headers['x-forwarded-for']
-  const ip =
-    (typeof forwardedFor === 'string'
-      ? forwardedFor.split(',')[0].trim()
-      : undefined) ??
-    req.socket.remoteAddress ??
-    'unknown'
-  hub.handleConnection(ws, ip)
-})
-
-// Graceful shutdown handler
-const shutdown = (): void => {
-  logger.info({ pid: process.pid }, 'shutting down')
-
-  // Stop accepting new connections
-  wss.close(() => {
-    logger.info({ pid: process.pid }, 'websocket server closed')
-  })
-
-  // Close all existing client connections
-  for (const client of wss.clients) {
-    client.close(1001, 'Server shutting down')
-  }
-
-  // Clean up plugin resources (timers, WebSocket connections, etc.)
-  hub.destroy()
-
-  logger.info({ pid: process.pid }, 'cleanup complete')
-  process.exit(0)
+export interface StartWorkerOptions {
+  notifyApi: AlchemyNotifyApi
+  signingKeyStore: SigningKeyStore
+  webhookRegistry: WebhookRegistry
 }
 
-process.on('SIGTERM', shutdown)
-process.on('SIGINT', shutdown)
+export function startWorker(opts: StartWorkerOptions): void {
+  const { webhookRegistry } = opts
+
+  const { listenPort, listenHost } = serverConfig
+
+  // Main serverlet - routes to webhook endpoints
+  const serverlet = pickPath<ExpressRequest>(
+    {
+      '/webhook/.+': pickMethod({
+        GET: healthCheckRoute,
+        HEAD: healthCheckRoute,
+        POST: withWebhookRegistry({ webhookRegistry })(webhookRoute)
+      })
+    },
+    notFoundRoute
+  )
+
+  // Create Express app
+  const app: Express = express()
+  // Use raw body parser to get the raw string for signature validation
+  app.use(express.text({ type: '*/*' }))
+  // Mount the serverlet
+  app.use(makeExpressRoute(serverlet))
+
+  const { webhookHost, webhookPort } = serverConfig
+  const webhookServer = app.listen(webhookPort, webhookHost, () => {
+    logger.info(
+      {
+        host: webhookHost,
+        port: webhookPort
+      },
+      'HTTP server listening'
+    )
+  })
+
+  const wss = new WebSocket.Server({
+    port: listenPort,
+    host: listenHost
+  })
+  logger.info({ port: listenPort }, 'websocket server listening')
+
+  const allPlugins = makeAllPlugins(opts)
+  const hub = makeAddressHub({ plugins: allPlugins })
+  wss.on('connection', (ws, req) => {
+    // Extract IP from X-Forwarded-For header (if behind proxy) or socket
+    const forwardedFor = req.headers['x-forwarded-for']
+    const ip =
+      (typeof forwardedFor === 'string'
+        ? forwardedFor.split(',')[0].trim()
+        : undefined) ??
+      req.socket.remoteAddress ??
+      'unknown'
+    hub.handleConnection(ws, ip)
+  })
+
+  // Graceful shutdown handler
+  const shutdown = (): void => {
+    logger.info({ pid: process.pid }, 'shutting down')
+
+    // Stop accepting new connections
+    wss.close(() => {
+      logger.info({ pid: process.pid }, 'websocket server closed')
+    })
+
+    // Close all existing client connections
+    for (const client of wss.clients) {
+      client.close(1001, 'Server shutting down')
+    }
+
+    // Clean up plugin resources (timers, WebSocket connections, etc.)
+    hub.destroy()
+
+    webhookServer.close()
+    logger.info('HTTP server stopped')
+
+    logger.info({ pid: process.pid }, 'cleanup complete')
+    process.exit(0)
+  }
+
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,53 @@
+import WebSocket from 'ws'
+
+import { makeAddressHub } from './hub'
+import { allPlugins } from './plugins/allPlugins'
+import { serverConfig } from './serverConfig'
+import { makeLogger } from './util/logger'
+
+const logger = makeLogger('server')
+
+const { listenPort, listenHost } = serverConfig
+
+const wss = new WebSocket.Server({
+  port: listenPort,
+  host: listenHost
+})
+logger.info({ port: listenPort }, 'websocket server listening')
+
+const hub = makeAddressHub({ plugins: allPlugins })
+wss.on('connection', (ws, req) => {
+  // Extract IP from X-Forwarded-For header (if behind proxy) or socket
+  const forwardedFor = req.headers['x-forwarded-for']
+  const ip =
+    (typeof forwardedFor === 'string'
+      ? forwardedFor.split(',')[0].trim()
+      : undefined) ??
+    req.socket.remoteAddress ??
+    'unknown'
+  hub.handleConnection(ws, ip)
+})
+
+// Graceful shutdown handler
+const shutdown = (): void => {
+  logger.info({ pid: process.pid }, 'shutting down')
+
+  // Stop accepting new connections
+  wss.close(() => {
+    logger.info({ pid: process.pid }, 'websocket server closed')
+  })
+
+  // Close all existing client connections
+  for (const client of wss.clients) {
+    client.close(1001, 'Server shutting down')
+  }
+
+  // Clean up plugin resources (timers, WebSocket connections, etc.)
+  hub.destroy()
+
+  logger.info({ pid: process.pid }, 'cleanup complete')
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)

--- a/test/plugins/alchemy.test.ts
+++ b/test/plugins/alchemy.test.ts
@@ -1,0 +1,546 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test
+} from '@jest/globals'
+import crypto from 'crypto'
+import { HttpResponse } from 'serverlet'
+
+import { makeAlchemy } from '../../src/plugins/alchemy'
+import { notifyApi } from '../../src/services'
+import { AddressPlugin } from '../../src/types/addressPlugin'
+import { SigningKeyStore } from '../../src/util/signingKeyStore'
+import { WebhookRegistry, WebhookRoute } from '../../src/util/webhookRegistry'
+
+const TEST_SIGNING_KEY = 'test-signing-key'
+
+function computeSignature(body: string, key: string): string {
+  return crypto.createHmac('sha256', key).update(body, 'utf8').digest('hex')
+}
+
+// Mock the Alchemy Notify API
+jest.mock('../../src/util/alchemyNotifyApi', () => {
+  return {
+    makeAlchemyNotifyApi: jest.fn(() => ({
+      createWebhook: jest.fn().mockImplementation(async () => ({
+        data: {
+          id: 'test-webhook-id',
+          network: 'ETH_MAINNET',
+          webhook_type: 'ADDRESS_ACTIVITY',
+          webhook_url: 'https://test.com/webhook',
+          is_active: true,
+          time_created: Date.now(),
+          signing_key: TEST_SIGNING_KEY,
+          version: 'V2'
+        }
+      })),
+      updateWebhookAddresses: jest
+        .fn()
+        .mockImplementation(async () => undefined),
+      getWebhookAddresses: jest.fn().mockImplementation(async () => ({
+        data: [],
+        pagination: { cursors: {}, total_count: 0 }
+      })),
+      getTeamWebhooks: jest.fn().mockImplementation(async () => []),
+      deleteWebhook: jest.fn().mockImplementation(async () => undefined)
+    }))
+  }
+})
+
+// Mock server config
+jest.mock('../../src/serverConfig', () => ({
+  serverConfig: {
+    publicUri: 'https://test.edge.app',
+    alchemyAuthToken: 'test-auth-token',
+    webhookHost: '127.0.0.1',
+    webhookPort: 8010,
+    serviceKeys: {
+      'dashboard.alchemy.com': ['test-api-key']
+    }
+  }
+}))
+
+describe('Alchemy plugin', () => {
+  const TEST_ADDRESS = '0xF5335367A46c2484f13abd051444E39775EA7b60'
+  const TEST_ADDRESS_LOWERCASE = TEST_ADDRESS.toLowerCase()
+  const TEST_SECOND_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+
+  let plugin: AddressPlugin
+  let mockSigningKeyStore: SigningKeyStore
+  let mockWebhookRegistry: WebhookRegistry
+  let registeredHandler: WebhookRoute | null = null
+
+  /**
+   * Builds a full Alchemy webhook payload and calls the registered handler
+   * with proper headers (including HMAC signature) and JSON body.
+   */
+  async function callRegisteredHandler(
+    network: string,
+    activity: unknown[]
+  ): Promise<HttpResponse> {
+    if (registeredHandler == null) {
+      throw new Error('registeredHandler is null')
+    }
+    const body = JSON.stringify({
+      webhookId: 'test-webhook-id',
+      id: 'test-event-id',
+      createdAt: new Date().toISOString(),
+      type: 'ADDRESS_ACTIVITY',
+      event: { network, activity }
+    })
+    const signature = computeSignature(body, TEST_SIGNING_KEY)
+    return await registeredHandler({
+      method: 'POST',
+      path: '/webhook/alchemy/ethereum',
+      version: '1.1',
+      headers: { 'x-alchemy-signature': signature },
+      req: { body } as any
+    })
+  }
+
+  /**
+   * Calls the handler with a raw body + custom headers (for testing
+   * invalid/missing signatures).
+   */
+  async function callHandlerRaw(
+    body: string,
+    headers: Record<string, string> = {}
+  ): Promise<HttpResponse> {
+    if (registeredHandler == null) {
+      throw new Error('registeredHandler is null')
+    }
+    return await registeredHandler({
+      method: 'POST',
+      path: '/webhook/alchemy/ethereum',
+      version: '1.1',
+      headers,
+      req: { body } as any
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    registeredHandler = null
+
+    // Create mock signing key store
+    mockSigningKeyStore = ({
+      setSigningKey: jest.fn(),
+      getSigningKey: jest.fn(async () => TEST_SIGNING_KEY),
+      recoverSigningKeys: jest.fn(async () => undefined)
+    } as unknown) as SigningKeyStore
+
+    // Create mock webhook registry
+    mockWebhookRegistry = {
+      registerHandler: jest.fn((_webhookKey: string, handler: WebhookRoute) => {
+        registeredHandler = handler
+      }),
+      unregisterHandler: jest.fn(),
+      handleWebhook: jest.fn(async () => ({ status: 200, body: 'OK' }))
+    }
+
+    plugin = makeAlchemy({
+      pluginId: 'ethereum',
+      network: 'ETH_MAINNET',
+      notifyApi: notifyApi,
+      signingKeyStore: mockSigningKeyStore,
+      webhookRegistry: mockWebhookRegistry
+    })
+  })
+
+  afterEach(() => {
+    plugin.destroy?.()
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  test('plugin instantiation', () => {
+    expect(plugin.pluginId).toBe('ethereum')
+    expect(mockWebhookRegistry.registerHandler).toHaveBeenCalledWith(
+      'alchemy/ethereum',
+      expect.any(Function)
+    )
+  })
+
+  test('subscribe should return true', async () => {
+    const result = await plugin.subscribe(TEST_ADDRESS)
+    expect(result).toBe(true)
+  })
+
+  test('subscribe should be idempotent', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    const result = await plugin.subscribe(TEST_ADDRESS)
+    expect(result).toBe(true)
+  })
+
+  test('unsubscribe should return true for subscribed address', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    const result = await plugin.unsubscribe(TEST_ADDRESS)
+    expect(result).toBe(true)
+  })
+
+  test('unsubscribe should return false for non-subscribed address', async () => {
+    const result = await plugin.unsubscribe(TEST_ADDRESS)
+    expect(result).toBe(false)
+  })
+
+  test('webhook activity should trigger update event for from address', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    // Simulate incoming webhook activity
+    const activity = [
+      {
+        blockNum: '0x100',
+        hash: '0xabc',
+        fromAddress: TEST_ADDRESS_LOWERCASE,
+        toAddress: '0xdef',
+        value: 1.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'external',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    // Call the registered handler
+    expect(registeredHandler).not.toBeNull()
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+      checkpoint: '256' // 0x100 in decimal
+    })
+  })
+
+  test('webhook activity should trigger update event for to address', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x200',
+        hash: '0xdef',
+        fromAddress: '0xabc',
+        toAddress: TEST_ADDRESS_LOWERCASE,
+        value: 2.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'external',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+      checkpoint: '512' // 0x200 in decimal
+    })
+  })
+
+  test('webhook activity should not trigger for unsubscribed addresses', async () => {
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x100',
+        hash: '0xabc',
+        fromAddress: TEST_ADDRESS_LOWERCASE,
+        toAddress: '0xdef',
+        value: 1.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'external',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).not.toHaveBeenCalled()
+  })
+
+  test('multiple addresses should all receive updates', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    await plugin.subscribe(TEST_SECOND_ADDRESS)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x300',
+        hash: '0xghi',
+        fromAddress: TEST_ADDRESS_LOWERCASE,
+        toAddress: TEST_SECOND_ADDRESS.toLowerCase(),
+        value: 1.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'external',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).toHaveBeenCalledTimes(2)
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+      checkpoint: '768'
+    })
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_SECOND_ADDRESS,
+      checkpoint: '768'
+    })
+  })
+
+  test('address normalization preserves original case', async () => {
+    const mixedCaseAddress = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12'
+    await plugin.subscribe(mixedCaseAddress)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x100',
+        hash: '0xabc',
+        fromAddress: mixedCaseAddress.toLowerCase(),
+        toAddress: '0xdef',
+        value: 1.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'external',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    // Should emit with original case
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: mixedCaseAddress,
+      checkpoint: '256'
+    })
+  })
+
+  test('destroy should unregister handler and clear state', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+
+    plugin.destroy?.()
+
+    expect(mockWebhookRegistry.unregisterHandler).toHaveBeenCalledWith(
+      'alchemy/ethereum',
+      expect.any(Function)
+    )
+  })
+
+  test('ERC20 token transfer activity should trigger update', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x400',
+        hash: '0xtoken',
+        fromAddress: TEST_ADDRESS_LOWERCASE,
+        toAddress: '0xrecipient',
+        value: 100.0,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'USDC',
+        category: 'erc20',
+        rawContract: {
+          rawValue: '0x5f5e100',
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          decimals: 6
+        },
+        typeTraceAddress: null
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+      checkpoint: '1024'
+    })
+  })
+
+  test('internal transfer activity should trigger update', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+
+    const updateHandler = jest.fn()
+    plugin.on('update', updateHandler)
+
+    const activity = [
+      {
+        blockNum: '0x500',
+        hash: '0xinternal',
+        fromAddress: '0xcontract',
+        toAddress: TEST_ADDRESS_LOWERCASE,
+        value: 0.5,
+        erc721TokenId: null,
+        erc1155Metadata: null,
+        asset: 'ETH',
+        category: 'internal',
+        rawContract: {
+          rawValue: '0x',
+          address: '',
+          decimals: 18
+        },
+        typeTraceAddress: 'call_0_1'
+      }
+    ]
+
+    await callRegisteredHandler('ETH_MAINNET', activity)
+
+    expect(updateHandler).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+      checkpoint: '1280'
+    })
+  })
+
+  // --- Batch processing tests ---
+
+  test('subscribe should create webhook after batch delay', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(notifyApi.createWebhook).toHaveBeenCalledWith({
+      network: 'ETH_MAINNET',
+      webhookUrl: 'https://test.edge.app/webhook/alchemy/ethereum',
+      addresses: [TEST_ADDRESS_LOWERCASE]
+    })
+  })
+
+  test('unsubscribe should delete webhook when no subscriptions remain', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    await plugin.unsubscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(notifyApi.deleteWebhook).toHaveBeenCalledWith('test-webhook-id')
+  })
+
+  test('subscribe + unsubscribe in same batch should cancel each other', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    await plugin.unsubscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(notifyApi.createWebhook).not.toHaveBeenCalled()
+  })
+
+  test('second subscribe should call updateWebhookAddresses', async () => {
+    await plugin.subscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    await plugin.subscribe(TEST_SECOND_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(notifyApi.updateWebhookAddresses).toHaveBeenCalledWith({
+      webhookId: 'test-webhook-id',
+      addressesToAdd: [TEST_SECOND_ADDRESS.toLowerCase()],
+      addressesToRemove: undefined
+    })
+  })
+
+  // --- Signature validation tests ---
+
+  test('missing signature header should return 401', async () => {
+    const body = JSON.stringify({
+      webhookId: 'test-webhook-id',
+      id: 'test-event-id',
+      createdAt: new Date().toISOString(),
+      type: 'ADDRESS_ACTIVITY',
+      event: { network: 'ETH_MAINNET', activity: [] }
+    })
+
+    const response = await callHandlerRaw(body, {})
+    expect(response.status).toBe(401)
+  })
+
+  test('invalid signature should return 401', async () => {
+    const body = JSON.stringify({
+      webhookId: 'test-webhook-id',
+      id: 'test-event-id',
+      createdAt: new Date().toISOString(),
+      type: 'ADDRESS_ACTIVITY',
+      event: { network: 'ETH_MAINNET', activity: [] }
+    })
+
+    const response = await callHandlerRaw(body, {
+      'x-alchemy-signature': 'bad-signature'
+    })
+    expect(response.status).toBe(401)
+  })
+
+  test('unknown webhook ID should return 401', async () => {
+    ;(mockSigningKeyStore.getSigningKey as jest.Mock).mockImplementation(
+      async () => undefined
+    )
+
+    const body = JSON.stringify({
+      webhookId: 'unknown-webhook-id',
+      id: 'test-event-id',
+      createdAt: new Date().toISOString(),
+      type: 'ADDRESS_ACTIVITY',
+      event: { network: 'ETH_MAINNET', activity: [] }
+    })
+    const signature = computeSignature(body, TEST_SIGNING_KEY)
+
+    const response = await callHandlerRaw(body, {
+      'x-alchemy-signature': signature
+    })
+    expect(response.status).toBe(401)
+  })
+
+  test('invalid payload body should return 401', async () => {
+    const response = await callHandlerRaw('not-json', {
+      'x-alchemy-signature': 'anything'
+    })
+    expect(response.status).toBe(401)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,10 +768,44 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/body-parser@*":
+  version "1.19.6"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
+  integrity sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cookie@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
+"@types/express-serve-static-core@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
+  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
+"@types/express@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
+  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^5.0.0"
+    "@types/serve-static" "^2"
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
@@ -779,6 +813,11 @@
   integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
   dependencies:
     "@types/node" "*"
+
+"@types/http-errors@*":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
+  integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
@@ -827,6 +866,31 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/qs@*":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.14.0.tgz#d8b60cecf62f2db0fb68e5e006077b9178b85de5"
+  integrity sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==
+
+"@types/range-parser@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/send@*":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-1.2.1.tgz#6a784e45543c18c774c049bff6d3dbaf045c9c74"
+  integrity sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/serve-static@^2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
+  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -941,6 +1005,14 @@ abitype@1.0.8, abitype@^1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
   integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
+
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
 
 acorn-jsx@^5.3.1:
   version "5.3.1"
@@ -1175,6 +1247,21 @@ bintrees@1.0.2:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
   integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.3"
+    http-errors "^2.0.0"
+    iconv-lite "^0.7.0"
+    on-finished "^2.4.1"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1232,6 +1319,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+bytes@^3.1.2, bytes@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1443,12 +1535,27 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
+content-disposition@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.1.tgz#a8b7bbeb2904befdfb6787e5c0c086959f605f9b"
+  integrity sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==
+
+content-type@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^0.7.2:
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
+cookie@^0.7.1, cookie@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -1527,6 +1634,13 @@ debug@^4.1.0, debug@^4.3.1:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -1567,6 +1681,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+depd@^2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -1619,6 +1738,11 @@ edge-server-tools@^0.2.19:
     node-fetch "^2.6.1"
     yavent "^0.1.3"
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
 ejs@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
@@ -1645,6 +1769,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+encodeurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -1742,6 +1871,11 @@ escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1941,6 +2075,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+etag@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
 eventemitter3@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
@@ -1991,6 +2130,40 @@ expect@^29.7.0:
     jest-matcher-utils "^29.7.0"
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
+
+express@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.1"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -2078,6 +2251,18 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+finalhandler@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
+  integrity sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -2127,6 +2312,16 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fs-extra@^9.0.0:
   version "9.1.0"
@@ -2366,6 +2561,17 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
@@ -2380,6 +2586,13 @@ husky@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -2425,10 +2638,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2510,6 +2728,11 @@ is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-regex@^1.0.5, is-regex@^1.1.1:
   version "1.1.1"
@@ -3228,10 +3451,20 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3264,12 +3497,24 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.12:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.0, mime-types@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -3373,6 +3618,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -3485,6 +3735,13 @@ on-exit-leak-free@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
   integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
+on-finished@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -3637,6 +3894,11 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parseurl@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 patch-package@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
@@ -3697,6 +3959,11 @@ path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
+path-to-regexp@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.3.0.tgz#aa818a6981f99321003a08987d3cec9c3474cd1f"
+  integrity sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -3861,6 +4128,14 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+proxy-addr@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -3903,6 +4178,13 @@ qs@^6.13.0:
   dependencies:
     side-channel "^1.1.0"
 
+qs@^6.14.0, qs@^6.14.1:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
+  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+  dependencies:
+    side-channel "^1.1.0"
+
 querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
@@ -3912,6 +4194,21 @@ quick-format-unescaped@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
+range-parser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
 react-is@^18.0.0:
   version "18.3.1"
@@ -4035,6 +4332,17 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
+
 run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
@@ -4051,6 +4359,11 @@ safe-stable-stringify@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -4084,6 +4397,33 @@ semver@^7.5.3, semver@^7.5.4, semver@^7.7.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
+send@^1.1.0, send@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
+  integrity sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==
+  dependencies:
+    debug "^4.4.3"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.1"
+    mime-types "^3.0.2"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.2"
+
+serve-static@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
+  integrity sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
+
 serverlet@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/serverlet/-/serverlet-0.1.2.tgz#3a29cb22a1648b575ba357274cb7b5000fc9cd72"
@@ -4100,6 +4440,11 @@ set-function-length@^1.2.2:
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
+
+setprototypeof@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4289,6 +4634,11 @@ statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+statuses@^2.0.2, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 strict-event-emitter@^0.5.1:
   version "0.5.1"
@@ -4523,6 +4873,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toidentifier@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 tough-cookie@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
@@ -4612,6 +4967,15 @@ type-fest@^4.26.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
+type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
+
 typescript@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
@@ -4631,6 +4995,11 @@ universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
+unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
 update-browserslist-db@^1.1.1:
   version "1.1.3"
@@ -4676,6 +5045,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vary@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
 viem@^2.27.0:
   version "2.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,10 +1332,10 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-cleaner-config@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/cleaner-config/-/cleaner-config-0.1.7.tgz#a5d204eeab5366dd81bafa321a89be8a58b40e10"
-  integrity sha512-M/g7yqqSlyE1MX/eoG8ZjBsiMHo/7HmDFq9EmQ3UEHq1kVX5YIoKOHE7nVq/fAiz7I8XLlpa+8Rvc4DcasQFtw==
+cleaner-config@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/cleaner-config/-/cleaner-config-0.1.10.tgz#5df39aedaa0837e073f65229a4a1a4da709ffbbc"
+  integrity sha512-LDPPn6Iv9e3Kdc+Dk+fPbyIaCzzqzuILnwgVJf53hic+1xh5VerfdN4NgzGX5dZC88BKUteCRwpFZxZ5TTcngQ==
   dependencies:
     cleaners "^0.3.8"
     minimist "^1.2.5"


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

- https://github.com/EdgeApp/edge-change-server/pull/12

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213206026575421
  - https://app.asana.com/0/0/1212754123530597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new externally reachable webhook HTTP surface and signature validation/auth logic, plus cluster-wide IPC relaying; failures here could drop or misroute activity updates or weaken webhook authentication.
> 
> **Overview**
> Adds an Alchemy-based address activity pipeline: workers now host an Express HTTP endpoint for `/webhook/*` (with GET/HEAD health checks) and dispatch incoming webhooks through a new `WebhookRegistry` to per-plugin handlers.
> 
> Introduces a new `alchemy` plugin that creates/updates/deletes Alchemy Address Activity webhooks, validates `X-Alchemy-Signature` via HMAC using recovered signing keys, debounces subscription address updates, and broadcasts webhook activity across cluster workers via IPC so all workers emit updates consistently.
> 
> Updates configuration/deps to support this (new `webhookHost`/`webhookPort` and `alchemyAuthToken`, adds `express` + types, bumps `cleaner-config`), and wires plugin construction through `makeAllPlugins(opts)` with Alchemy enabled for multiple EVM networks plus Solana; includes comprehensive Jest tests for the plugin behavior and signature/auth paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d41ce085fff00b5e0c5f8d00bbf52c79716879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->