### PR TITLE
refactor(server): unify webhook and websocket on one listener

### DIFF
--- a/src/plugins/alchemy.ts
+++ b/src/plugins/alchemy.ts
@@ -28,6 +28,10 @@ import { WebhookRegistry, WebhookRoute } from '../util/webhookRegistry'
 // Reset to undefined on failure so retries can create a fresh promise.
 let teamWebhooksPromise: Promise<WebhookInfo[]> | undefined
 
+export function resetAlchemyTeamWebhooksCache(): void {
+  teamWebhooksPromise = undefined
+}
+
 export interface AlchemyOptions {
   pluginId: string
   network: AlchemyNetwork
@@ -108,13 +112,17 @@ export function makeAlchemy(opts: AlchemyOptions): AddressPlugin {
       const webhooks = await teamWebhooksPromise
       const expectedUrl = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
 
-      // Find webhooks for this network
-      const networkWebhooks = webhooks.filter(
+      // Only manage webhooks owned by this server endpoint.
+      // In shared Alchemy accounts, other change-server instances may
+      // manage webhooks for the same network using different URLs.
+      const managedNetworkWebhooks = webhooks.filter(
         (w: WebhookInfo) =>
-          w.network === network && w.webhook_type === 'ADDRESS_ACTIVITY'
+          w.network === network &&
+          w.webhook_type === 'ADDRESS_ACTIVITY' &&
+          w.webhook_url === expectedUrl
       )
 
-      for (const webhook of networkWebhooks) {
+      for (const webhook of managedNetworkWebhooks) {
         if (!webhook.is_active) {
           // Delete paused webhooks
           logger.info({
@@ -135,34 +143,12 @@ export function makeAlchemy(opts: AlchemyOptions): AddressPlugin {
           webhookId = webhook.id
           signingKeyStore.setSigningKey(webhook.id, webhook.signing_key)
 
-          // Update URL if different
-          if (webhook.webhook_url !== expectedUrl) {
-            logger.info({
-              webhookId: webhook.id,
-              oldUrl: webhook.webhook_url,
-              newUrl: expectedUrl,
-              msg: 'Updating webhook URL'
-            })
-            try {
-              await notifyApi.updateWebhook({
-                webhookId: webhook.id,
-                webhookUrl: expectedUrl
-              })
-            } catch (err) {
-              logger.error({
-                err,
-                webhookId: webhook.id,
-                msg: 'Failed to update webhook URL'
-              })
-            }
-          }
-
           logger.info({
             webhookId: webhook.id,
             msg: 'Reusing existing webhook'
           })
         } else {
-          // Delete extra active webhooks (we only need one per network)
+          // Delete extra active webhooks for this server endpoint
           logger.info({
             webhookId: webhook.id,
             msg: 'Deleting extra webhook'

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -17,8 +17,6 @@ const asServerConfig = asObject({
   listenPort: asOptional(asNumber, 8008),
   metricsHost: asOptional(asString, '127.0.0.1'),
   metricsPort: asOptional(asNumber, 8009),
-  webhookHost: asOptional(asString, '127.0.0.1'),
-  webhookPort: asOptional(asNumber, 8010),
   publicUri: asOptional(asString, 'https://address1.edge.app'),
 
   // Alchemy webhook:

--- a/src/util/signingKeyStore.ts
+++ b/src/util/signingKeyStore.ts
@@ -1,3 +1,4 @@
+import { serverConfig } from '../serverConfig'
 import { AlchemyNotifyApi } from './alchemyNotifyApi'
 import { Logger, makeLogger } from './logger'
 
@@ -36,14 +37,19 @@ export function makeSigningKeyStore(
   async function doRecover(): Promise<void> {
     logger.info({ msg: 'Recovering signing keys from Alchemy API' })
     const webhooks = await notifyApi.getTeamWebhooks()
+    const webhookPrefix = `${serverConfig.publicUri}/webhook/`
+    let recoveredCount = 0
 
     for (const webhook of webhooks) {
+      // Only trust webhook IDs owned by this server endpoint.
+      if (!webhook.webhook_url.startsWith(webhookPrefix)) continue
       signingKeys.set(webhook.id, webhook.signing_key)
+      recoveredCount++
     }
 
     hasRecovered = true
     logger.info({
-      count: webhooks.length,
+      count: recoveredCount,
       msg: 'Recovered signing keys'
     })
   }

--- a/test/plugins/alchemy.test.ts
+++ b/test/plugins/alchemy.test.ts
@@ -10,12 +10,13 @@ import crypto from 'crypto'
 import { HttpResponse } from 'serverlet'
 
 import { makeAlchemy } from '../../src/plugins/alchemy'
-import { notifyApi } from '../../src/services'
 import { AddressPlugin } from '../../src/types/addressPlugin'
+import { makeAlchemyNotifyApi } from '../../src/util/alchemyNotifyApi'
 import { SigningKeyStore } from '../../src/util/signingKeyStore'
 import { WebhookRegistry, WebhookRoute } from '../../src/util/webhookRegistry'
 
 const TEST_SIGNING_KEY = 'test-signing-key'
+const notifyApi = makeAlchemyNotifyApi()
 
 function computeSignature(body: string, key: string): string {
   return crypto.createHmac('sha256', key).update(body, 'utf8').digest('hex')
@@ -55,8 +56,6 @@ jest.mock('../../src/serverConfig', () => ({
   serverConfig: {
     publicUri: 'https://test.edge.app',
     alchemyAuthToken: 'test-auth-token',
-    webhookHost: '127.0.0.1',
-    webhookPort: 8010,
     serviceKeys: {
       'dashboard.alchemy.com': ['test-api-key']
     }
@@ -147,7 +146,8 @@ describe('Alchemy plugin', () => {
       network: 'ETH_MAINNET',
       notifyApi: notifyApi,
       signingKeyStore: mockSigningKeyStore,
-      webhookRegistry: mockWebhookRegistry
+      webhookRegistry: mockWebhookRegistry,
+      normalizeAddress: address => address.toLowerCase()
     })
   })
 

--- a/test/plugins/alchemy.test.ts
+++ b/test/plugins/alchemy.test.ts
@@ -9,7 +9,10 @@ import {
 import crypto from 'crypto'
 import { HttpResponse } from 'serverlet'
 
-import { makeAlchemy } from '../../src/plugins/alchemy'
+import {
+  makeAlchemy,
+  resetAlchemyTeamWebhooksCache
+} from '../../src/plugins/alchemy'
 import { AddressPlugin } from '../../src/types/addressPlugin'
 import { makeAlchemyNotifyApi } from '../../src/util/alchemyNotifyApi'
 import { SigningKeyStore } from '../../src/util/signingKeyStore'
@@ -123,6 +126,7 @@ describe('Alchemy plugin', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
+    resetAlchemyTeamWebhooksCache()
     registeredHandler = null
 
     // Create mock signing key store
@@ -485,6 +489,46 @@ describe('Alchemy plugin', () => {
       addressesToAdd: [TEST_SECOND_ADDRESS.toLowerCase()],
       addressesToRemove: undefined
     })
+  })
+
+  test('should ignore active webhook on same network with different URL', async () => {
+    plugin.destroy?.()
+    jest.clearAllMocks()
+    resetAlchemyTeamWebhooksCache()
+    const getTeamWebhooksMock = notifyApi.getTeamWebhooks as jest.Mock
+    getTeamWebhooksMock.mockImplementationOnce(async () => [
+      {
+        id: 'foreign-webhook-id',
+        network: 'ETH_MAINNET',
+        webhook_type: 'ADDRESS_ACTIVITY',
+        webhook_url: 'https://other.edge.app/webhook/alchemy/ethereum',
+        is_active: true,
+        time_created: Date.now(),
+        signing_key: TEST_SIGNING_KEY,
+        version: 'V2'
+      }
+    ])
+
+    plugin = makeAlchemy({
+      pluginId: 'ethereum',
+      network: 'ETH_MAINNET',
+      notifyApi: notifyApi,
+      signingKeyStore: mockSigningKeyStore,
+      webhookRegistry: mockWebhookRegistry,
+      normalizeAddress: address => address.toLowerCase()
+    })
+
+    await plugin.subscribe(TEST_ADDRESS)
+    await jest.advanceTimersByTimeAsync(1000)
+
+    expect(notifyApi.createWebhook).toHaveBeenCalledWith({
+      network: 'ETH_MAINNET',
+      webhookUrl: 'https://test.edge.app/webhook/alchemy/ethereum',
+      addresses: [TEST_ADDRESS_LOWERCASE]
+    })
+    expect(notifyApi.deleteWebhook).not.toHaveBeenCalledWith(
+      'foreign-webhook-id'
+    )
   })
 
   // --- Signature validation tests ---

--- a/test/util/signingKeyStore.test.ts
+++ b/test/util/signingKeyStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, jest, test } from '@jest/globals'
+
+import { AlchemyNotifyApi } from '../../src/util/alchemyNotifyApi'
+import { makeSigningKeyStore } from '../../src/util/signingKeyStore'
+
+jest.mock('../../src/serverConfig', () => ({
+  serverConfig: {
+    publicUri: 'https://my.edge.app'
+  }
+}))
+
+describe('makeSigningKeyStore', function () {
+  test('recovers only signing keys for this server webhook URL', async function () {
+    const notifyApi = {
+      getTeamWebhooks: jest.fn(async () => [
+        {
+          id: 'owned-webhook-id',
+          network: 'ETH_MAINNET',
+          webhook_type: 'ADDRESS_ACTIVITY',
+          webhook_url: 'https://my.edge.app/webhook/alchemy/ethereum',
+          is_active: true,
+          time_created: Date.now(),
+          signing_key: 'owned-signing-key',
+          version: 'V2'
+        },
+        {
+          id: 'foreign-webhook-id',
+          network: 'ETH_MAINNET',
+          webhook_type: 'ADDRESS_ACTIVITY',
+          webhook_url: 'https://other.edge.app/webhook/alchemy/ethereum',
+          is_active: true,
+          time_created: Date.now(),
+          signing_key: 'foreign-signing-key',
+          version: 'V2'
+        }
+      ])
+    }
+
+    const signingKeyStore = makeSigningKeyStore({
+      notifyApi: (notifyApi as unknown) as AlchemyNotifyApi
+    })
+
+    await signingKeyStore.recoverSigningKeys()
+
+    await expect(
+      signingKeyStore.getSigningKey('owned-webhook-id')
+    ).resolves.toBe('owned-signing-key')
+    await expect(
+      signingKeyStore.getSigningKey('foreign-webhook-id')
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Serve webhook HTTP routes and websocket upgrades from the same port, block websocket upgrades on /webhook paths, and remove obsolete webhook host/port config usage.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes listener topology by serving webhooks and websockets from the same HTTP server and tightening webhook ownership filtering, which could affect connectivity or webhook lifecycle if misconfigured.
> 
> **Overview**
> Unifies webhook HTTP handling and websocket connections onto the same `listenHost`/`listenPort` by running Express behind a single `http` server and handling websocket upgrades manually, while explicitly rejecting upgrades on `/webhook` paths.
> 
> Removes `webhookHost`/`webhookPort` from `serverConfig` and updates shutdown/logging accordingly. Alchemy webhook management is tightened to only reuse/delete webhooks and recover signing keys for webhooks whose `webhook_url` matches this server’s `publicUri`, with new tests and a `resetAlchemyTeamWebhooksCache()` helper to avoid cross-test cache contamination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1328ae142afe1677fb8554bf1fa9bfb90515f6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213457928534597