### PR TITLE
feat(tatum): implement Tatum plugin for non-Alchemy chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Added Tatum webhook-based plugin for bitcoin, bitcoincash, dogecoin, litecoin, ripple, tezos, and tron.
+
 ## 0.3.0 (2026-03-16)
 
 - added: Added flexible service key matching with URL templating.

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -1,0 +1,206 @@
+# Adding A Plugin
+
+This guide is the basic blueprint for adding a new address plugin to the change server. It focuses on the common structure shared by polling plugins, RPC plugins, websocket plugins, and webhook plugins.
+
+## What A Plugin Must Do
+
+Every plugin implements `AddressPlugin` from `src/types/addressPlugin.ts`.
+
+That means it must provide:
+
+- a stable `pluginId`
+- an `on()` event emitter
+- `subscribe(address)`
+- `unsubscribe(address)`
+
+It may also provide:
+
+- `scanAddress(address, checkpoint)` if the plugin can check for changes on demand
+- `destroy()` if the plugin owns timers, sockets, route handlers, or other resources
+
+The only event most plugins emit is:
+
+- `update: { address, checkpoint? }`
+
+That event tells the hub that a client should rescan that address. The plugin does not describe what changed.
+
+## Files You Usually Need
+
+Most new plugins touch at least these files:
+
+- `src/plugins/<pluginName>.ts`: the plugin implementation
+- `src/plugins/allPlugins.ts`: registration in the server
+- `test/plugins/<pluginName>.test.ts`: unit tests
+
+Some plugins also need:
+
+- `src/util/...`: provider-specific API wrappers, scan adapters, or shared helpers
+- `src/serverConfig.ts` and `changeServerConfig.json`: config or credentials
+- `CHANGELOG.md`: if the repo's release workflow expects a visible feature note
+
+## Minimal Plugin Shape
+
+Use this as the starting point for a new plugin:
+
+```ts
+import { makeEvents } from 'yavent'
+
+import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import { makeLogger } from '../util/logger'
+
+export interface ExamplePluginOptions {
+  pluginId: string
+  normalizeAddress?: (address: string) => string
+}
+
+export function makeExamplePlugin(opts: ExamplePluginOptions): AddressPlugin {
+  const { pluginId, normalizeAddress = address => address } = opts
+
+  const [on, emit] = makeEvents<PluginEvents>()
+  const logger = makeLogger('example', pluginId)
+
+  const subscribedAddresses = new Map<string, string>()
+
+  return {
+    pluginId,
+    on,
+
+    async subscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+      if (subscribedAddresses.has(normalized)) return true
+
+      subscribedAddresses.set(normalized, address)
+      logger.info({ address }, 'Subscribed address')
+      return true
+    },
+
+    async unsubscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+      if (!subscribedAddresses.has(normalized)) return false
+
+      subscribedAddresses.delete(normalized)
+      logger.info({ address }, 'Unsubscribed address')
+      return true
+    },
+
+    async scanAddress(
+      address: string,
+      checkpoint?: string
+    ): Promise<boolean> {
+      return false
+    },
+
+    destroy() {
+      subscribedAddresses.clear()
+    }
+  }
+}
+```
+
+Once the provider integration exists, the plugin's job is just to map provider activity into `emit('update', { address, checkpoint })`.
+
+## How Plugins Fit Into The Server
+
+The wiring is:
+
+1. `makeAllPlugins()` creates plugin instances.
+2. `makeAddressHub()` subscribes clients to plugins by `pluginId`.
+3. The hub listens for plugin `update` events.
+4. The hub forwards those updates to subscribed websocket clients.
+
+That means a plugin should:
+
+- keep its own provider-facing state
+- emit updates for addresses it is actually tracking
+- avoid leaking provider-specific details outside the plugin boundary
+
+## Registering The Plugin
+
+Add the factory call to `src/plugins/allPlugins.ts`.
+
+Typical patterns:
+
+- one plugin instance per chain
+- one shared implementation with different `pluginId` or network options
+- injected helpers like `notifyApi`, `signingKeyStore`, or `webhookRegistry`
+
+Keep `pluginId` stable. Clients use it to subscribe.
+
+## Design Questions To Answer First
+
+Before you write code, decide:
+
+- What external system detects the change: polling, RPC subscriptions, websocket stream, or webhooks?
+- Do addresses need normalization for matching?
+- Can the provider return a useful checkpoint like block height?
+- Can the plugin do `scanAddress()`, or must the client rescan unconditionally?
+- What state must survive restarts?
+- What resources must be cleaned up in `destroy()`?
+
+These choices strongly affect the implementation.
+
+## Address Handling
+
+Most plugins need normalized lookup keys and original addresses for emitted updates.
+
+Recommended pattern:
+
+- store subscriptions by normalized address
+- preserve the original subscribed address when emitting `update`
+- make normalization injectable when the same implementation supports multiple chains
+
+Examples:
+
+- EVM addresses are usually matched with lowercase
+- Solana/base58-style addresses are case-sensitive
+- Bitcoin-like addresses often should not be rewritten unless the provider requires it
+
+## Checkpoints
+
+If the provider exposes a reliable height or cursor, include it in the emitted update:
+
+```ts
+emit('update', {
+  address: originalAddress,
+  checkpoint: blockHeight.toString()
+})
+```
+
+If not, emit the update without a checkpoint and let the client decide how much to rescan.
+
+## Error Handling
+
+A plugin should be conservative about local state:
+
+- only mark a subscribe as active once the remote subscribe succeeds
+- preserve local state when remote unsubscribe fails, unless the provider guarantees the resource is gone
+- retry only clearly transient failures
+- log enough context to debug provider issues
+
+If the provider can silently lose subscriptions, consider whether the plugin should emit `subLost`.
+
+## Testing Checklist
+
+Every plugin should have tests for:
+
+- instantiation
+- `pluginId`
+- subscribe idempotency
+- unsubscribe behavior
+- tracked vs untracked address updates
+- checkpoint behavior
+- failure paths for provider calls
+- cleanup in `destroy()`
+
+Add provider-specific tests as needed:
+
+- retry/backoff
+- connection recovery
+- payload validation
+- address normalization
+- startup reconciliation
+- duplicate delivery handling
+
+## When To Use The Webhook Guide
+
+If the provider pushes activity into `/webhook/...`, also follow `docs/webhook-based-plugins.md`.

--- a/docs/webhook-based-plugins.md
+++ b/docs/webhook-based-plugins.md
@@ -1,0 +1,357 @@
+# Writing A Webhook-Based Plugin
+
+This guide explains how to implement a plugin that receives address activity through `/webhook/...` instead of polling or maintaining a long-lived upstream socket.
+
+Use this together with `docs/adding-a-plugin.md`.
+
+## When A Webhook Plugin Is A Good Fit
+
+Choose a webhook-based plugin when the provider:
+
+- can push address activity to a callback URL
+- can create or update remote subscriptions on demand
+- includes enough information in the payload to emit `update`
+- has a security model the server can validate locally
+
+As of this writing, `Alchemy` and `Tatum` are the two working examples in this repo.
+
+## Pick The Provider Model First
+
+Before writing code, decide which of these models the provider uses:
+
+- one shared webhook per chain/network with a mutable address list
+- one remote subscription per address
+
+That choice drives almost every design decision.
+
+Shared-webhook providers behave more like `Alchemy`:
+
+- local state tracks one `webhookId`
+- subscribe/unsubscribe mutates the provider's address list
+- batching is usually important
+- multi-worker fanout matters because one webhook delivery can apply to many addresses
+
+Per-address providers behave more like `Tatum`:
+
+- local state maps address to provider subscription id
+- subscribe/unsubscribe creates and deletes remote resources
+- retries often matter more than batching
+- duplicate deliveries are more likely to need explicit deduplication
+
+## Basic Structure
+
+A webhook plugin usually needs:
+
+- a factory in `src/plugins/<name>.ts`
+- a `webhookKey`
+- a route handler registered with `WebhookRegistry`
+- local subscription state
+- provider API helpers
+
+The high-level shape looks like this:
+
+```ts
+import crypto from 'crypto'
+import { makeEvents } from 'yavent'
+
+import { serverConfig } from '../serverConfig'
+import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import { makeLogger } from '../util/logger'
+import { WebhookRegistry, WebhookRoute } from '../util/webhookRegistry'
+
+export interface ExampleWebhookOptions {
+  pluginId: string
+  webhookRegistry: WebhookRegistry
+  normalizeAddress?: (address: string) => string
+}
+
+export function makeExampleWebhookPlugin(
+  opts: ExampleWebhookOptions
+): AddressPlugin {
+  const {
+    pluginId,
+    webhookRegistry,
+    normalizeAddress = address => address
+  } = opts
+
+  const [on, emit] = makeEvents<PluginEvents>()
+  const logger = makeLogger('exampleWebhook', pluginId)
+
+  const WEBHOOK_KEY = `example/${pluginId}`
+  const WEBHOOK_URL = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
+  const subscribedAddresses = new Map<string, string>()
+
+  const webhookRoute: WebhookRoute = async request => {
+    const rawBody = typeof request.req.body === 'string' ? request.req.body : ''
+
+    // 1. authenticate raw body
+    // 2. parse payload
+    // 3. map provider activity to tracked addresses
+    // 4. emit update events
+
+    return {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: 'OK'
+    }
+  }
+
+  webhookRegistry.registerHandler(WEBHOOK_KEY, webhookRoute)
+
+  return {
+    pluginId,
+    on,
+
+    async subscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+      subscribedAddresses.set(normalized, address)
+      return true
+    },
+
+    async unsubscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+      return subscribedAddresses.delete(normalized)
+    },
+
+    destroy() {
+      webhookRegistry.unregisterHandler(WEBHOOK_KEY, webhookRoute)
+      subscribedAddresses.clear()
+    }
+  }
+}
+```
+
+The rest of the work is about making each step production-safe.
+
+## Step 1: Define The Callback URL
+
+Always derive the callback URL from `serverConfig.publicUri`:
+
+```ts
+const WEBHOOK_KEY = `provider/${pluginId}`
+const EXPECTED_WEBHOOK_URL = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
+```
+
+Do not hard-code provider callback URLs anywhere else.
+
+### Critical: Define The Ownership Boundary
+
+This deserves to be treated as a separate design requirement, not a small implementation detail.
+
+When the provider account is shared by multiple deployments, a webhook plugin must not reuse, update, or delete remote resources unless it can prove they belong to the current server instance.
+
+If this boundary is wrong, the plugin can:
+
+- steal another deployment's webhook or subscription
+- rewrite a callback URL that belongs to a different server
+- delete another deployment's remote resource during cleanup
+- create hard-to-debug delivery gaps where webhooks are accepted but routed to the wrong server
+
+Recommended checks:
+
+- match the provider webhook/subscription type
+- match the chain or network
+- require the remote callback URL to belong to this server namespace
+
+In practice, this usually means "only manage resources whose callback URL matches the current `publicUri` namespace".
+
+Both existing webhook plugins rely on this safeguard:
+
+- `Alchemy` only manages webhooks whose callback URL exactly matches the expected URL for this deployment
+- `Tatum` only reuses subscriptions whose callback URL belongs to this server namespace, even when repairing stale paths
+
+If a provider does not give enough metadata to establish ownership safely, prefer creating new isolated resources over mutating ambiguous existing ones.
+
+## Step 2: Reconcile Remote State On Startup
+
+A webhook plugin should initialize itself by looking at provider-side state before it handles normal traffic.
+
+Typical startup work:
+
+- list existing remote webhooks or subscriptions
+- reuse the matching active resource if possible
+- delete paused or duplicate resources if appropriate
+- repair stale callback URLs if the provider allows it
+- recover metadata needed to validate future deliveries
+
+Two examples from the current codebase:
+
+- `Alchemy` reuses an existing active webhook for the same URL and deletes extras
+- `Tatum` discovers per-address subscriptions and updates stale callback URLs to the current endpoint
+
+> [!IMPORTANT]  
+> Keep startup idempotent. Initialization should be safe to run more than once without creating duplicate remote resources, deleting the wrong resource, or drifting local state away from provider state.
+
+## Step 3: Subscribe And Unsubscribe Conservatively
+
+`subscribe()` and `unsubscribe()` should keep local state aligned with remote state.
+
+For subscribe:
+
+- normalize the address
+- short-circuit if already subscribed
+- create or update the remote provider resource
+- only mark the address active locally once the provider call succeeds
+
+For unsubscribe:
+
+- return `false` if the address is unknown
+- delete or update the remote provider resource
+- only clear local state when the provider confirms success, or when a `404`/equivalent proves the resource is already gone
+
+If the provider API is rate-limited:
+
+- batch address changes for shared-webhook providers
+- retry transient failures for per-address providers
+
+## Step 4: Authenticate The Incoming Webhook From The Raw Body
+
+Webhook signatures must be validated against the exact raw request body. This server already uses `express.text({ type: '*/*' })` in the worker so plugins can read the unmodified body string.
+
+Recommended flow inside the route handler:
+
+1. read `request.req.body` as a string
+2. read the provider signature header
+3. fetch the relevant secret or signing key
+4. compute the expected HMAC
+5. compare with `crypto.timingSafeEqual`
+6. reject failures with `401`
+
+Do authentication before trusting network ids, webhook ids, or payload contents any more than necessary.
+
+## Step 5: Parse And Validate Payloads Strictly
+
+After signature verification, parse the payload with cleaners and reject malformed data early.
+
+Recommended approach:
+
+- parse from the raw JSON string
+- require only the fields the plugin actually uses
+- return `400` for invalid but authenticated payloads
+- log enough context to debug bad payloads without leaking secrets
+
+If the provider can send multiple event types to the same endpoint, validate the event type explicitly before processing.
+
+## Step 6: Map Provider Activity To Tracked Addresses
+
+Once the payload is trusted, convert provider activity into `update` events.
+
+Good patterns:
+
+- normalize provider addresses for matching
+- preserve the original subscribed address when emitting
+- collect affected addresses into a `Set` before emitting
+- derive the best checkpoint available from the payload
+
+Examples:
+
+- `Alchemy` scans the batch for matching `fromAddress` and `toAddress`, then emits one update per matched address with the highest block number
+- `Tatum` emits the payload address with `blockNumber` when present
+
+Only emit updates for addresses currently tracked by the plugin.
+
+## Step 7: Decide On Duplicate Handling
+
+Webhook delivery is often at-least-once.
+
+You need an explicit answer to this question: what happens if the same event is delivered twice?
+
+Options:
+
+- ignore duplicates because repeated `update` events are harmless
+- track processed event ids or tx ids in memory
+- persist deduplication state if replay after restart would be costly
+
+`Tatum` uses `txId` deduplication. `Alchemy` currently accepts the risk of repeated updates because the downstream effect is just "rescan this address".
+
+Do not skip this decision. Make it deliberate.
+
+## Step 8: Handle Multi-Worker Delivery
+
+This server may run more than one worker. A webhook can be received by a worker that does not hold the websocket subscriptions for the affected addresses.
+
+If your plugin stores subscription state only in process memory, you need a delivery strategy:
+
+- broadcast activity across workers, like `Alchemy`
+- move subscription state into shared storage
+- ensure webhook traffic is pinned to a single worker
+
+Without one of these, valid webhooks may be acknowledged but never forwarded to clients.
+
+This is the biggest operational difference between "webhook works locally" and "webhook works in production".
+
+## Step 9: Add Retry And Backoff Where It Matters
+
+Webhook plugins make two kinds of network calls:
+
+- provider control-plane calls such as create/update/delete webhook
+- optional data-plane calls such as fallback scans or metadata lookup
+
+At minimum, decide:
+
+- which errors are retryable
+- whether `429` should always back off
+- how many attempts are allowed
+- whether failed operations should be re-queued
+
+The existing patterns are:
+
+- `Alchemy`: debounce and retry address mutations later
+- `Tatum`: retry create/update/delete with exponential backoff
+
+## Step 10: Keep `destroy()` Honest
+
+`destroy()` should clean up local resources and route registration.
+
+Usually that means:
+
+- unregister the webhook route
+- clear timers
+- remove IPC listeners
+- clear caches or in-memory maps
+
+Remote provider cleanup is a design choice, not an automatic requirement.
+
+Examples:
+
+- `Alchemy` removes the remote webhook only when there are no addresses left
+- `Tatum` does not delete remote subscriptions during `destroy()`
+
+Pick one lifecycle model and document it in the plugin.
+
+## Webhook-Specific Test Checklist
+
+A webhook plugin should have tests for:
+
+- handler registration with the expected `webhookKey`
+- subscribe/unsubscribe idempotency
+- startup reconciliation
+- ownership boundaries
+- missing signature
+- invalid signature
+- malformed payload
+- unexpected event type or network mismatch
+- duplicate delivery behavior
+- update emission for tracked addresses
+- no update emission for untracked addresses
+- cleanup in `destroy()`
+
+If the plugin uses clustering or IPC, add tests for that too.
+
+## Two Practical Templates
+
+Use `Alchemy` as the template when the provider gives you:
+
+- one webhook resource per network
+- mutable address membership
+- per-webhook signing keys
+- clustered delivery concerns
+
+Use `Tatum` as the template when the provider gives you:
+
+- one subscription per address
+- a stable event or transaction id
+- provider APIs that need retry/backoff
+- an optional scan endpoint for checkpoint-aware verification
+
+If a new provider falls somewhere in the middle, choose the closer model and copy only the parts that actually match the provider's behavior.

--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -5,6 +5,7 @@ import { WebhookRegistry } from '../util/webhookRegistry'
 import { makeAlchemy } from './alchemy'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
+import { makeTatum, tatumChainMap } from './tatum'
 
 interface AllPluginOptions {
   notifyApi: AlchemyNotifyApi
@@ -13,32 +14,58 @@ interface AllPluginOptions {
 }
 
 const evmNormalizeAddress = (addr: string): string => addr.toLowerCase()
+const identityNormalizeAddress = (addr: string): string => addr
 
 export function makeAllPlugins(opts: AllPluginOptions): AddressPlugin[] {
   const { notifyApi, signingKeyStore, webhookRegistry } = opts
 
   return [
-    // Bitcoin family:
-    // makeBlockbook({
-    //   pluginId: 'bitcoin',
-    //   url: 'wss://btcbook.nownodes.io/wss/{{apiKey}}'
-    // }),
-    // makeBlockbook({
-    //   pluginId: 'bitcoincash',
-    //   url: 'wss://bchbook.nownodes.io/wss/{{apiKey}}'
-    // }),
-    // makeBlockbook({
-    //   pluginId: 'dogecoin',
-    //   url: 'wss://dogebook.nownodes.io/wss/{{apiKey}}'
-    // }),
-    // makeBlockbook({
-    //   pluginId: 'litecoin',
-    //   url: 'wss://ltcbook.nownodes.io/wss/{{apiKey}}'
-    // }),
-    // makeBlockbook({
-    //   pluginId: 'qtum',
-    //   url: 'wss://qtum-blockbook.nownodes.io/wss/{{apiKey}}'
-    // }),
+    // -------------------------------------------------------------------------
+    // Tatum ADDRESS_EVENT webhook plugins (7 blockchains)
+    // See src/plugins/tatum.ts for chain identifier reference.
+    // -------------------------------------------------------------------------
+    makeTatum({
+      pluginId: 'bitcoin',
+      chain: tatumChainMap.bitcoin,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'bitcoincash',
+      chain: tatumChainMap.bitcoincash,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'dogecoin',
+      chain: tatumChainMap.dogecoin,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'litecoin',
+      chain: tatumChainMap.litecoin,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'ripple',
+      chain: tatumChainMap.ripple,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'tezos',
+      chain: tatumChainMap.tezos,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
+    makeTatum({
+      pluginId: 'tron',
+      chain: tatumChainMap.tron,
+      webhookRegistry,
+      normalizeAddress: identityNormalizeAddress
+    }),
 
     // EVM chains using EvmRpc polling (not supported by Alchemy):
     makeEvmRpc({

--- a/src/plugins/tatum.ts
+++ b/src/plugins/tatum.ts
@@ -1,0 +1,860 @@
+/**
+ * Tatum Address Activity webhook plugin.
+ *
+ * ## How it works
+ * 1. On `subscribe(address)`, creates a Tatum ADDRESS_EVENT subscription that
+ *    POSTs to `/webhook/tatum/<pluginId>` whenever the address has activity.
+ * 2. On `unsubscribe(address)`, deletes the Tatum subscription.
+ * 3. Incoming webhooks are verified via HMAC-SHA256 and processed idempotently.
+ *
+ * ## Webhook verification
+ * When `serverConfig.tatumHmacSecret` is set:
+ *   - The secret is included in each subscription `attr.hmacSecret` so Tatum
+ *     signs every delivery.
+ *   - Each inbound request must carry `X-Tatum-Signature`, computed as
+ *     `HMAC-SHA256(rawBody, tatumHmacSecret)` (hex).
+ *   - Requests with a missing or invalid signature are rejected with HTTP 401.
+ *   - When no secret is configured verification is skipped (dev/test mode).
+ *
+ * ## Idempotency
+ * Tatum delivers webhooks with at-least-once semantics. Each event payload
+ * includes a `txId` field used as the idempotency key. Already-seen `txId`
+ * values are tracked in a bounded LRU-like Set (`processedTxIds`). Duplicate
+ * deliveries return HTTP 200 immediately without re-emitting the update event.
+ * The set is capped at `MAX_PROCESSED_IDS` entries to bound memory usage.
+ *
+ * ## Retry / backoff for subscription API calls
+ * Calls to `createSubscription` and `deleteSubscription` retry on transient
+ * failures (network errors, HTTP 5xx) with exponential backoff:
+ *   attempt 1 → 1 s delay
+ *   attempt 2 → 2 s delay
+ *   attempt 3 → 4 s delay
+ *   attempt 4 → 8 s delay
+ *   attempt 5 → 16 s delay  (then throws)
+ */
+
+import {
+  asArray,
+  asJSON,
+  asNumber,
+  asObject,
+  asOptional,
+  asString
+} from 'cleaners'
+import crypto from 'crypto'
+import { makeEvents } from 'yavent'
+
+import { serverConfig } from '../serverConfig'
+import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import { makeLogger } from '../util/logger'
+import { pickRandom } from '../util/pickRandom'
+import { serviceKeysFromUrl } from '../util/serviceKeys'
+import { snooze } from '../util/snooze'
+import { WebhookRegistry, WebhookRoute } from '../util/webhookRegistry'
+
+const TATUM_API_URL = 'https://api.tatum.io'
+
+/**
+ * Mapping from Edge plugin IDs to Tatum blockchain chain identifiers.
+ *
+ * Chain identifiers follow Tatum's naming convention (e.g. bitcoin-mainnet).
+ * Used when creating ADDRESS_EVENT subscriptions via the Tatum v4 API.
+ *
+ * Reference: https://docs.tatum.io/reference/notifications-supported-chains
+ *
+ * Tatum plugins covered (7 total):
+ *  - bitcoin         -> bitcoin-mainnet
+ *  - bitcoincash     -> bch-mainnet
+ *  - dogecoin        -> doge-mainnet
+ *  - litecoin        -> litecoin-core-mainnet
+ *  - ripple          -> ripple-mainnet   (XRP)
+ *  - tezos           -> tezos-mainnet
+ *  - tron            -> tron-mainnet
+ */
+export const tatumChainMap: Readonly<Record<string, string>> = {
+  bitcoin: 'bitcoin-mainnet',
+  bitcoincash: 'bch-mainnet',
+  dogecoin: 'doge-mainnet',
+  litecoin: 'litecoin-core-mainnet',
+  ripple: 'ripple-mainnet',
+  tezos: 'tezos-mainnet',
+  tron: 'tron-mainnet'
+}
+
+/** All plugin IDs managed by Tatum. */
+export const TATUM_PLUGIN_IDS: readonly string[] = Object.keys(tatumChainMap)
+
+/** Max retries for outbound Tatum API calls (subscription create/delete). */
+const MAX_API_RETRIES = 5
+
+/** Initial backoff delay (ms) for API retries; doubles on each attempt. */
+const INITIAL_RETRY_DELAY_MS = 1000
+
+/**
+ * Max number of processed txIds to keep in the idempotency set.
+ * Oldest entries are evicted when the set exceeds this size.
+ */
+const MAX_PROCESSED_IDS = 10_000
+const SUBSCRIPTION_PAGE_SIZE = 50
+const TATUM_TRANSACTION_SCAN_CHAINS = new Set<string>([
+  'bsc-mainnet',
+  'bsc-testnet',
+  'celo-mainnet',
+  'celo-testnet',
+  'chiliz-mainnet',
+  'ethereum-mainnet',
+  'ethereum-holesky',
+  'ethereum-sepolia',
+  'mocachain-devnet',
+  'polygon-mainnet',
+  'polygon-amoy',
+  'tezos-mainnet'
+])
+
+// Module-level cached promise (shared across all makeTatum instances).
+// Reset to undefined on failure so retries can create a fresh promise.
+let allSubscriptionsPromise: Promise<TatumSubscriptionInfo[]> | undefined
+
+export interface TatumOptions {
+  pluginId: string
+  chain: string
+  webhookRegistry: WebhookRegistry
+  /** Normalize addresses for comparisons. Defaults to identity. */
+  normalizeAddress?: (address: string) => string
+}
+
+export function makeTatum(opts: TatumOptions): AddressPlugin {
+  const {
+    pluginId,
+    chain,
+    webhookRegistry,
+    normalizeAddress = addr => addr
+  } = opts
+
+  const WEBHOOK_KEY = `tatum/${pluginId}`
+  const EXPECTED_WEBHOOK_URL = `${serverConfig.publicUri}/webhook/${WEBHOOK_KEY}`
+
+  const [on, emit] = makeEvents<PluginEvents>()
+
+  const logger = makeLogger('tatum', pluginId)
+
+  // address (normalized) → Tatum subscriptionId
+  const subscriptions = new Map<string, string>()
+
+  // Idempotency: set of already-processed txIds.
+  // When MAX_PROCESSED_IDS is reached the oldest half is dropped.
+  const processedTxIds = new Set<string>()
+
+  // Whether we've initialized (discovered existing subscriptions).
+  let initialized = false
+  let initializingPromise: Promise<void> | null = null
+
+  function getApiKey(): string | undefined {
+    const apiKeys = serviceKeysFromUrl(serverConfig.serviceKeys, TATUM_API_URL)
+    return apiKeys.length > 0 ? pickRandom(apiKeys) : undefined
+  }
+
+  function makeHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    }
+    const apiKey = getApiKey()
+    if (apiKey != null) {
+      headers['x-api-key'] = apiKey
+    }
+    return headers
+  }
+
+  /**
+   * Whether a subscription's webhook URL belongs to this server instance
+   * and this specific plugin. Guards against cross-server subscription
+   * takeover when multiple deployments share the same Tatum API key.
+   *
+   * Uses prefix + suffix matching rather than exact equality against
+   * EXPECTED_WEBHOOK_URL so that doInitialize can discover and migrate
+   * stale subscriptions whose path structure changed between deployments.
+   */
+  function isOwnedWebhookUrl(url: string): boolean {
+    return (
+      url.startsWith(serverConfig.publicUri + '/') &&
+      url.endsWith(`/webhook/${WEBHOOK_KEY}`)
+    )
+  }
+
+  function canonicalChain(chainId: string): string {
+    const normalized = chainId.toLowerCase()
+    const aliasMap: Record<string, string> = {
+      'bitcoin-mainnet': 'btc',
+      btc: 'btc',
+      'bch-mainnet': 'bch',
+      bch: 'bch',
+      'doge-mainnet': 'doge',
+      doge: 'doge',
+      'litecoin-core-mainnet': 'ltc',
+      ltc: 'ltc',
+      'ripple-mainnet': 'xrp',
+      xrp: 'xrp',
+      'tezos-mainnet': 'tezos',
+      tezos: 'tezos',
+      'tron-mainnet': 'tron',
+      tron: 'tron'
+    }
+    return aliasMap[normalized] ?? normalized
+  }
+
+  function matchesConfiguredChain(subscriptionChain: string): boolean {
+    return canonicalChain(subscriptionChain) === canonicalChain(chain)
+  }
+
+  async function listAllSubscriptions(): Promise<TatumSubscriptionInfo[]> {
+    if (allSubscriptionsPromise == null) {
+      allSubscriptionsPromise = (async () => {
+        const results: TatumSubscriptionInfo[] = []
+        let offset = 0
+
+        while (true) {
+          const params = new URLSearchParams({
+            pageSize: SUBSCRIPTION_PAGE_SIZE.toString(),
+            offset: offset.toString()
+          })
+          const response = await fetch(
+            `${TATUM_API_URL}/v4/subscription?${params.toString()}`,
+            {
+              headers: makeHeaders()
+            }
+          )
+
+          if (!response.ok) {
+            const text = await response.text()
+            throw new Error(
+              `Tatum listSubscriptions error: ${response.status} ${response.statusText} - ${text}`
+            )
+          }
+
+          const page = asTatumSubscriptionsResponse(await response.text())
+          results.push(...page)
+
+          if (page.length < SUBSCRIPTION_PAGE_SIZE) break
+          offset += SUBSCRIPTION_PAGE_SIZE
+        }
+
+        return results
+      })()
+    }
+
+    try {
+      return await allSubscriptionsPromise
+    } catch (err) {
+      allSubscriptionsPromise = undefined
+      throw err
+    }
+  }
+
+  async function updateSubscriptionUrl(
+    subscriptionId: string,
+    webhookUrl: string
+  ): Promise<void> {
+    let lastError: unknown
+    for (let attempt = 0; attempt < MAX_API_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+        await snooze(delayMs)
+      }
+
+      try {
+        const response = await fetch(
+          `${TATUM_API_URL}/v4/subscription/${subscriptionId}`,
+          {
+            method: 'PUT',
+            headers: makeHeaders(),
+            body: JSON.stringify({ url: webhookUrl })
+          }
+        )
+
+        if (response.ok) return
+
+        const text = await response.text()
+        if (response.status === 429 || response.status >= 500) {
+          lastError = new Error(
+            `Tatum updateSubscriptionUrl HTTP ${response.status}: ${text}`
+          )
+          continue
+        }
+
+        throw new Error(
+          `Tatum updateSubscriptionUrl error: ${response.status} ${response.statusText} - ${text}`
+        )
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message.startsWith('Tatum')) {
+          throw err // Non-retryable errors propagate immediately
+        }
+        lastError = err
+      }
+    }
+
+    if (lastError instanceof Error) throw lastError
+    throw new Error('updateSubscriptionUrl failed after max retries')
+  }
+
+  async function lookupSubscriptionByAddress(
+    address: string
+  ): Promise<TatumSubscriptionInfo | undefined> {
+    let offset = 0
+
+    while (true) {
+      const params = new URLSearchParams({
+        pageSize: SUBSCRIPTION_PAGE_SIZE.toString(),
+        offset: offset.toString(),
+        address
+      })
+
+      const response = await fetch(
+        `${TATUM_API_URL}/v4/subscription?${params.toString()}`,
+        {
+          headers: makeHeaders()
+        }
+      )
+
+      if (!response.ok) {
+        const text = await response.text()
+        throw new Error(
+          `Tatum lookupSubscriptionByAddress error: ${response.status} ${response.statusText} - ${text}`
+        )
+      }
+
+      const page = asTatumSubscriptionsResponse(await response.text())
+      const match = page.find(
+        item =>
+          item.type === 'ADDRESS_EVENT' &&
+          matchesConfiguredChain(item.attr.chain) &&
+          normalizeAddress(item.attr.address) === normalizeAddress(address)
+      )
+      if (match != null) return match
+
+      if (page.length < SUBSCRIPTION_PAGE_SIZE) return undefined
+      offset += SUBSCRIPTION_PAGE_SIZE
+    }
+  }
+
+  async function initialize(): Promise<void> {
+    if (initialized) return
+    if (initializingPromise != null) return await initializingPromise
+
+    initializingPromise = doInitialize()
+    try {
+      await initializingPromise
+    } finally {
+      initializingPromise = null
+    }
+  }
+
+  async function doInitialize(): Promise<void> {
+    logger.info({ msg: 'Discovering existing subscriptions' })
+    const all = await listAllSubscriptions()
+    let discoveredCount = 0
+
+    for (const sub of all) {
+      if (
+        sub.type !== 'ADDRESS_EVENT' ||
+        !matchesConfiguredChain(sub.attr.chain)
+      )
+        continue
+      if (!isOwnedWebhookUrl(sub.attr.url)) continue
+
+      const normalizedAddress = normalizeAddress(sub.attr.address)
+      if (sub.attr.url !== EXPECTED_WEBHOOK_URL) {
+        logger.info(
+          {
+            address: normalizedAddress,
+            subscriptionId: sub.id,
+            oldUrl: sub.attr.url,
+            newUrl: EXPECTED_WEBHOOK_URL
+          },
+          'Updating subscription URL'
+        )
+        await updateSubscriptionUrl(sub.id, EXPECTED_WEBHOOK_URL)
+      }
+
+      subscriptions.set(normalizedAddress, sub.id)
+      discoveredCount += 1
+    }
+
+    initialized = true
+    logger.info({ discoveredCount }, 'Subscription discovery complete')
+  }
+
+  /**
+   * Record a txId as processed, evicting the oldest half of entries when
+   * the set reaches MAX_PROCESSED_IDS to keep memory bounded.
+   */
+  function markProcessed(txId: string): void {
+    if (processedTxIds.size >= MAX_PROCESSED_IDS) {
+      // Evict oldest half (Set iteration preserves insertion order)
+      const evictCount = Math.floor(MAX_PROCESSED_IDS / 2)
+      let i = 0
+      for (const id of processedTxIds) {
+        if (i++ >= evictCount) break
+        processedTxIds.delete(id)
+      }
+    }
+    processedTxIds.add(txId)
+  }
+
+  /**
+   * Verify the HMAC-SHA256 signature from Tatum.
+   *
+   * Tatum computes: HMAC-SHA256(rawBody, hmacSecret) and sends the hex
+   * digest in the `X-Tatum-Signature` request header.
+   *
+   * Returns true when verification passes or when no secret is configured
+   * (permissive dev-mode).
+   */
+  function verifySignature(rawBody: string, signature: string): boolean {
+    const secret = serverConfig.tatumHmacSecret
+    if (secret == null || secret === '') {
+      // No secret configured — skip verification (dev/test mode)
+      return true
+    }
+
+    const expected = crypto
+      .createHmac('sha256', secret)
+      .update(rawBody, 'utf8')
+      .digest('hex')
+
+    try {
+      return crypto.timingSafeEqual(
+        Buffer.from(signature),
+        Buffer.from(expected)
+      )
+    } catch {
+      // Buffer lengths differ — signature is invalid
+      return false
+    }
+  }
+
+  /**
+   * Create a Tatum ADDRESS_EVENT subscription for the given address.
+   * Retries on transient failures with exponential backoff.
+   *
+   * Backoff schedule (ms): 1000, 2000, 4000, 8000, 16000
+   */
+  async function createSubscription(address: string): Promise<string> {
+    const body: Record<string, unknown> = {
+      type: 'ADDRESS_EVENT',
+      attr: {
+        chain,
+        address,
+        url: EXPECTED_WEBHOOK_URL
+      }
+    }
+
+    // Include HMAC secret in subscription so Tatum signs deliveries
+    const secret = serverConfig.tatumHmacSecret
+    if (secret != null && secret !== '') {
+      ;(body.attr as Record<string, unknown>).hmacSecret = secret
+    }
+
+    let lastError: unknown
+    for (let attempt = 0; attempt < MAX_API_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+        logger.warn(
+          { attempt, delayMs, address },
+          'Retrying createSubscription'
+        )
+        await snooze(delayMs)
+      }
+
+      try {
+        const response = await fetch(`${TATUM_API_URL}/v4/subscription`, {
+          method: 'POST',
+          headers: makeHeaders(),
+          body: JSON.stringify(body)
+        })
+
+        if (response.status === 429) {
+          // Rate-limited — always retry
+          lastError = new Error(`Tatum rate limit (429) on attempt ${attempt}`)
+          continue
+        }
+
+        if (!response.ok) {
+          const text = await response.text()
+          if (response.status === 403) {
+            const errData = parseTatumErrorBody(text)
+            if (
+              errData?.errorCode ===
+              'subscription.exists.on.address-and-currency'
+            ) {
+              const existing = await lookupSubscriptionByAddress(address)
+              if (existing != null) {
+                if (existing.attr.url === EXPECTED_WEBHOOK_URL) {
+                  return existing.id
+                }
+                if (isOwnedWebhookUrl(existing.attr.url)) {
+                  await updateSubscriptionUrl(existing.id, EXPECTED_WEBHOOK_URL)
+                  return existing.id
+                }
+              }
+              throw new Error(
+                'Tatum subscription already exists for address but is not owned by this server'
+              )
+            }
+          }
+          // Only retry on 5xx server errors
+          if (response.status >= 500) {
+            lastError = new Error(
+              `Tatum createSubscription HTTP ${response.status}: ${text}`
+            )
+            continue
+          }
+          throw new Error(
+            `Tatum createSubscription error: ${response.status} ${response.statusText} - ${text}`
+          )
+        }
+
+        const data = asTatumSubscriptionResponse(await response.text())
+        return data.id
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message.startsWith('Tatum')) {
+          throw err // Non-retryable errors propagate immediately
+        }
+        // Network/transport errors — retry
+        lastError = err
+      }
+    }
+
+    if (lastError instanceof Error) throw lastError
+    throw new Error('createSubscription failed after max retries')
+  }
+
+  /**
+   * Delete a Tatum subscription. Retries on transient failures.
+   */
+  async function deleteSubscription(subscriptionId: string): Promise<void> {
+    let lastError: unknown
+    for (let attempt = 0; attempt < MAX_API_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+        await snooze(delayMs)
+      }
+
+      try {
+        const response = await fetch(
+          `${TATUM_API_URL}/v4/subscription/${subscriptionId}`,
+          {
+            method: 'DELETE',
+            headers: makeHeaders()
+          }
+        )
+
+        if (response.ok || response.status === 404) {
+          return // Success or already deleted
+        }
+
+        if (response.status === 429 || response.status >= 500) {
+          const text = await response.text()
+          lastError = new Error(
+            `Tatum deleteSubscription HTTP ${response.status}: ${text}`
+          )
+          continue
+        }
+
+        const text = await response.text()
+        throw new Error(
+          `Tatum deleteSubscription error: ${response.status} ${response.statusText} - ${text}`
+        )
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message.startsWith('Tatum')) {
+          throw err
+        }
+        lastError = err
+      }
+    }
+
+    if (lastError instanceof Error) throw lastError
+    throw new Error('deleteSubscription failed after max retries')
+  }
+
+  /**
+   * Scan an address to determine if it has any updates since `checkpoint`.
+   * Returns true if there are new transactions, false if already up-to-date.
+   */
+  async function scanAddress(
+    address: string,
+    checkpoint?: string
+  ): Promise<boolean> {
+    if (checkpoint == null) {
+      return true
+    }
+
+    // Tatum's /v4/data/transactions endpoint only supports a subset of chains.
+    // For unsupported chains, skip scanning and rely on webhook delivery.
+    if (!TATUM_TRANSACTION_SCAN_CHAINS.has(chain)) {
+      return true
+    }
+
+    const normalizedAddress = normalizeAddress(address)
+    const fromBlock = Number(checkpoint) + 1
+
+    const params = new URLSearchParams({
+      chain,
+      addresses: normalizedAddress,
+      fromBlock: fromBlock.toString(),
+      pageSize: '1'
+    })
+
+    const headers = makeHeaders()
+    const response = await fetch(
+      `${TATUM_API_URL}/v4/data/transactions?${params.toString()}`,
+      { headers }
+    )
+
+    if (response.status === 429) {
+      throw new Error('Tatum rate limit exceeded')
+    }
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(
+        `Tatum scan error: ${response.status} ${response.statusText} - ${text}`
+      )
+    }
+
+    const data = asTatumTransactionsResponse(await response.text())
+    return data.result.length > 0
+  }
+
+  /**
+   * Incoming webhook handler registered with the WebhookRegistry.
+   *
+   * Processing order:
+   *  1. Parse raw body
+   *  2. Verify HMAC-SHA256 signature (X-Tatum-Signature header)
+   *  3. Check idempotency (txId already processed → 200 OK, no re-emit)
+   *  4. Emit update event for tracked address
+   */
+  const webhookRoute: WebhookRoute = async request => {
+    const rawBody: string =
+      typeof request.req.body === 'string' ? request.req.body : ''
+
+    // --- Parse payload ---
+    let payload: TatumWebhookPayload
+    try {
+      payload = asTatumWebhookPayload(rawBody)
+    } catch (err: unknown) {
+      logger.warn({ err, rawBody }, 'Invalid Tatum webhook payload')
+      return {
+        status: 400,
+        headers: { 'content-type': 'text/plain' },
+        body: 'Invalid payload'
+      }
+    }
+
+    // --- Signature verification ---
+    const signature = request.headers['x-tatum-signature']
+    if (typeof signature !== 'string') {
+      const secret = serverConfig.tatumHmacSecret
+      if (secret != null && secret !== '') {
+        logger.warn({ pluginId }, 'Missing X-Tatum-Signature header')
+        return {
+          status: 401,
+          headers: { 'content-type': 'text/plain' },
+          body: 'Missing signature'
+        }
+      }
+    } else if (!verifySignature(rawBody, signature)) {
+      logger.warn({ pluginId }, 'Invalid Tatum webhook signature')
+      return {
+        status: 401,
+        headers: { 'content-type': 'text/plain' },
+        body: 'Invalid signature'
+      }
+    }
+
+    // --- Idempotency ---
+    if (payload.txId != null) {
+      if (processedTxIds.has(payload.txId)) {
+        // Already processed — return 200 without re-emitting
+        logger.info(
+          { txId: payload.txId, pluginId },
+          'Duplicate webhook delivery, ignoring'
+        )
+        return {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+          body: 'OK'
+        }
+      }
+      markProcessed(payload.txId)
+    }
+
+    // --- Emit update for tracked address ---
+    const normalizedAddress = normalizeAddress(payload.address)
+    if (subscriptions.has(normalizedAddress)) {
+      emit('update', {
+        address: normalizedAddress,
+        checkpoint:
+          payload.blockNumber != null
+            ? payload.blockNumber.toString()
+            : undefined
+      })
+    }
+
+    return {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+      body: 'OK'
+    }
+  }
+
+  webhookRegistry.registerHandler(WEBHOOK_KEY, webhookRoute)
+  initialize().catch((err: unknown) => {
+    allSubscriptionsPromise = undefined
+    logger.error({ err }, 'Failed to initialize on startup')
+  })
+
+  const plugin: AddressPlugin = {
+    pluginId,
+    on,
+
+    async subscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+
+      try {
+        await initialize()
+        if (subscriptions.has(normalized)) {
+          return true
+        }
+
+        const subscriptionId = await createSubscription(address)
+        subscriptions.set(normalized, subscriptionId)
+        logger.info({ address, subscriptionId }, 'Created subscription')
+        return true
+      } catch (err: unknown) {
+        logger.error({ err, address }, 'Failed to subscribe')
+        return false
+      }
+    },
+
+    async unsubscribe(address: string): Promise<boolean> {
+      const normalized = normalizeAddress(address)
+      const subscriptionId = subscriptions.get(normalized)
+      if (subscriptionId == null) {
+        return false
+      }
+
+      try {
+        await deleteSubscription(subscriptionId)
+        subscriptions.delete(normalized)
+        logger.info(
+          { address: normalized, subscriptionId },
+          'Deleted subscription'
+        )
+        return true
+      } catch (err: unknown) {
+        logger.error({ err, address: normalized }, 'Failed to unsubscribe')
+        return false
+      }
+    },
+
+    scanAddress,
+
+    destroy() {
+      webhookRegistry.unregisterHandler(WEBHOOK_KEY, webhookRoute)
+
+      subscriptions.clear()
+      processedTxIds.clear()
+    }
+  }
+
+  return plugin
+}
+
+//
+// Cleaners & Types
+//
+
+const asTatumSubscriptionResponse = asJSON(
+  asObject({
+    id: asString
+  })
+)
+
+const asTatumSubscriptionInfo = asObject({
+  id: asString,
+  type: asString,
+  attr: asObject({
+    address: asString,
+    chain: asString,
+    url: asString
+  })
+})
+
+type TatumSubscriptionInfo = ReturnType<typeof asTatumSubscriptionInfo>
+
+const asTatumSubscriptionsResponse = asJSON(asArray(asTatumSubscriptionInfo))
+
+const asTatumErrorResponse = asJSON(
+  asObject({
+    errorCode: asOptional(asString),
+    message: asOptional(asString)
+  })
+)
+
+function parseTatumErrorBody(text: string): TatumErrorResponse | undefined {
+  try {
+    return asTatumErrorResponse(text)
+  } catch {
+    return undefined
+  }
+}
+
+type TatumErrorResponse = ReturnType<typeof asTatumErrorResponse>
+
+const asTatumTransactionsResponse = asJSON(
+  asObject({
+    result: asArray(
+      asObject({
+        blockNumber: asNumber,
+        hash: asString
+      })
+    ),
+    prevPage: asOptional(asString),
+    nextPage: asOptional(asString)
+  })
+)
+
+/**
+ * Tatum ADDRESS_EVENT webhook payload.
+ *
+ * Example:
+ * ```json
+ * {
+ *   "address": "0xF64E82131BE01618487Da5142fc9d289cbb60E9d",
+ *   "amount": "0.001",
+ *   "asset": "ETH",
+ *   "blockNumber": 2913059,
+ *   "counterAddress": "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990",
+ *   "txId": "0x062d236ccc044f68194a04008e98c3823271dc26160a4db9ae9303f9ecfc7bf6",
+ *   "type": "native",
+ *   "chain": "ethereum-mainnet",
+ *   "subscriptionType": "ADDRESS_EVENT"
+ * }
+ * ```
+ */
+const asTatumWebhookPayload = asJSON(
+  asObject({
+    address: asString,
+    txId: asOptional(asString),
+    blockNumber: asOptional(asNumber),
+    type: asOptional(asString),
+    chain: asOptional(asString),
+    asset: asOptional(asString),
+    amount: asOptional(asString),
+    counterAddress: asOptional(asString),
+    subscriptionType: asOptional(asString)
+  })
+)
+
+type TatumWebhookPayload = ReturnType<typeof asTatumWebhookPayload>

--- a/src/plugins/tatum.ts
+++ b/src/plugins/tatum.ts
@@ -17,11 +17,13 @@
  *   - When no secret is configured verification is skipped (dev/test mode).
  *
  * ## Idempotency
- * Tatum delivers webhooks with at-least-once semantics. Each event payload
- * includes a `txId` field used as the idempotency key. Already-seen `txId`
- * values are tracked in a bounded LRU-like Set (`processedTxIds`). Duplicate
- * deliveries return HTTP 200 immediately without re-emitting the update event.
- * The set is capped at `MAX_PROCESSED_IDS` entries to bound memory usage.
+ * Tatum delivers webhooks with at-least-once semantics. The composite key
+ * `txId:address` is used for idempotency so that the same transaction
+ * correctly triggers updates for every subscribed address it touches while
+ * still deduplicating retries. Already-seen keys are tracked in a bounded
+ * LRU-like Set (`processedKeys`). Duplicate deliveries return HTTP 200
+ * immediately without re-emitting the update event. The set is capped at
+ * `MAX_PROCESSED_IDS` entries to bound memory usage.
  *
  * ## Retry / backoff for subscription API calls
  * Calls to `createSubscription` and `deleteSubscription` retry on transient
@@ -141,9 +143,9 @@ export function makeTatum(opts: TatumOptions): AddressPlugin {
   // address (normalized) → Tatum subscriptionId
   const subscriptions = new Map<string, string>()
 
-  // Idempotency: set of already-processed txIds.
+  // Idempotency: set of already-processed keys (txId:address).
   // When MAX_PROCESSED_IDS is reached the oldest half is dropped.
-  const processedTxIds = new Set<string>()
+  const processedKeys = new Set<string>()
 
   // Whether we've initialized (discovered existing subscriptions).
   let initialized = false
@@ -384,20 +386,20 @@ export function makeTatum(opts: TatumOptions): AddressPlugin {
   }
 
   /**
-   * Record a txId as processed, evicting the oldest half of entries when
-   * the set reaches MAX_PROCESSED_IDS to keep memory bounded.
+   * Record an idempotency key as processed, evicting the oldest half of
+   * entries when the set reaches MAX_PROCESSED_IDS to keep memory bounded.
    */
-  function markProcessed(txId: string): void {
-    if (processedTxIds.size >= MAX_PROCESSED_IDS) {
+  function markProcessed(key: string): void {
+    if (processedKeys.size >= MAX_PROCESSED_IDS) {
       // Evict oldest half (Set iteration preserves insertion order)
       const evictCount = Math.floor(MAX_PROCESSED_IDS / 2)
       let i = 0
-      for (const id of processedTxIds) {
+      for (const id of processedKeys) {
         if (i++ >= evictCount) break
-        processedTxIds.delete(id)
+        processedKeys.delete(id)
       }
     }
-    processedTxIds.add(txId)
+    processedKeys.add(key)
   }
 
   /**
@@ -673,9 +675,12 @@ export function makeTatum(opts: TatumOptions): AddressPlugin {
     }
 
     // --- Idempotency ---
+    // Key on txId + address so the same tx touching two subscribed
+    // addresses is processed for each address independently.
+    const normalizedAddress = normalizeAddress(payload.address)
     if (payload.txId != null) {
-      if (processedTxIds.has(payload.txId)) {
-        // Already processed — return 200 without re-emitting
+      const idempotencyKey = `${payload.txId}:${normalizedAddress}`
+      if (processedKeys.has(idempotencyKey)) {
         logger.info(
           { txId: payload.txId, pluginId },
           'Duplicate webhook delivery, ignoring'
@@ -686,11 +691,10 @@ export function makeTatum(opts: TatumOptions): AddressPlugin {
           body: 'OK'
         }
       }
-      markProcessed(payload.txId)
+      markProcessed(idempotencyKey)
     }
 
     // --- Emit update for tracked address ---
-    const normalizedAddress = normalizeAddress(payload.address)
     if (subscriptions.has(normalizedAddress)) {
       emit('update', {
         address: normalizedAddress,
@@ -764,7 +768,7 @@ export function makeTatum(opts: TatumOptions): AddressPlugin {
       webhookRegistry.unregisterHandler(WEBHOOK_KEY, webhookRoute)
 
       subscriptions.clear()
-      processedTxIds.clear()
+      processedKeys.clear()
     }
   }
 

--- a/src/serverConfig.ts
+++ b/src/serverConfig.ts
@@ -22,6 +22,12 @@ const asServerConfig = asObject({
   // Alchemy webhook:
   alchemyAuthToken: asOptional(asString, ''),
 
+  // Tatum webhook HMAC secret.
+  // When set, Tatum will sign each webhook delivery with this secret and
+  // the server will verify the X-Tatum-Signature header on every request.
+  // Leave empty to skip signature verification (development only).
+  tatumHmacSecret: asOptional(asString, ''),
+
   // Resources:
   serviceKeys: asOptional(asServiceKeys, () => ({
     '<service-host>': ['<api-key>']

--- a/test/plugins/alchemy.test.ts
+++ b/test/plugins/alchemy.test.ts
@@ -19,7 +19,6 @@ import { SigningKeyStore } from '../../src/util/signingKeyStore'
 import { WebhookRegistry, WebhookRoute } from '../../src/util/webhookRegistry'
 
 const TEST_SIGNING_KEY = 'test-signing-key'
-const notifyApi = makeAlchemyNotifyApi()
 
 function computeSignature(body: string, key: string): string {
   return crypto.createHmac('sha256', key).update(body, 'utf8').digest('hex')
@@ -71,6 +70,7 @@ describe('Alchemy plugin', () => {
   const TEST_SECOND_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 
   let plugin: AddressPlugin
+  let notifyApi: ReturnType<typeof makeAlchemyNotifyApi>
   let mockSigningKeyStore: SigningKeyStore
   let mockWebhookRegistry: WebhookRegistry
   let registeredHandler: WebhookRoute | null = null
@@ -145,10 +145,12 @@ describe('Alchemy plugin', () => {
       handleWebhook: jest.fn(async () => ({ status: 200, body: 'OK' }))
     }
 
+    notifyApi = makeAlchemyNotifyApi()
+
     plugin = makeAlchemy({
       pluginId: 'ethereum',
       network: 'ETH_MAINNET',
-      notifyApi: notifyApi,
+      notifyApi,
       signingKeyStore: mockSigningKeyStore,
       webhookRegistry: mockWebhookRegistry,
       normalizeAddress: address => address.toLowerCase()

--- a/test/plugins/tatum.test.ts
+++ b/test/plugins/tatum.test.ts
@@ -1,0 +1,857 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test
+} from '@jest/globals'
+import crypto from 'crypto'
+import { HttpResponse } from 'serverlet'
+
+import {
+  makeTatum,
+  TATUM_PLUGIN_IDS,
+  tatumChainMap
+} from '../../src/plugins/tatum'
+import { AddressPlugin } from '../../src/types/addressPlugin'
+import { WebhookRegistry, WebhookRoute } from '../../src/util/webhookRegistry'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const TEST_HMAC_SECRET = 'test-hmac-secret-for-tatum'
+
+/**
+ * Compute the expected X-Tatum-Signature for a given raw body + secret.
+ * Matches the verifySignature logic in tatum.ts.
+ */
+function computeSignature(body: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(body, 'utf8').digest('hex')
+}
+
+// NOTE: jest.mock() is hoisted before variable declarations, so we cannot
+// reference TEST_HMAC_SECRET here. Use the same literal value.
+jest.mock('../../src/serverConfig', () => ({
+  serverConfig: {
+    publicUri: 'https://test.edge.app',
+    tatumHmacSecret: 'test-hmac-secret-for-tatum',
+    serviceKeys: {
+      'api.tatum.io': ['test-api-key']
+    }
+  }
+}))
+
+// Mock snooze so retry backoff delays are instant in tests
+jest.mock('../../src/util/snooze', () => ({
+  snooze: jest.fn().mockImplementation(async () => {})
+}))
+
+// Mock fetch for Tatum API calls
+const mockFetch = jest.fn<typeof fetch>()
+global.fetch = mockFetch as typeof fetch
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a valid Tatum webhook payload JSON string. */
+function buildPayload(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    address: '0xabc123',
+    txId: 'tx-001',
+    blockNumber: 100,
+    type: 'native',
+    chain: 'bitcoin-mainnet',
+    subscriptionType: 'ADDRESS_EVENT',
+    ...overrides
+  })
+}
+
+/**
+ * Create a minimal mock Response object.
+ * Cast via unknown to satisfy objectLiteralTypeAssertions: "never" rule.
+ */
+function makeMockResponse(ok: boolean, status: number, body: string): Response {
+  const mock = {
+    ok,
+    status,
+    statusText: String(status),
+    text: async (): Promise<string> => body
+  }
+  return (mock as unknown) as Response
+}
+
+/** Simulate an inbound webhook call to the registered handler. */
+async function callHandler(
+  handler: WebhookRoute,
+  body: string,
+  headers: Record<string, string> = {}
+): Promise<HttpResponse> {
+  const signature = computeSignature(body, TEST_HMAC_SECRET)
+  return await handler({
+    method: 'POST',
+    path: '/webhook/tatum/bitcoin',
+    version: '1.1',
+    headers: { 'x-tatum-signature': signature, ...headers },
+    req: { body } as any
+  })
+}
+
+/** Call handler without computing a correct signature. */
+async function callHandlerRaw(
+  handler: WebhookRoute,
+  body: string,
+  headers: Record<string, string> = {}
+): Promise<HttpResponse> {
+  return await handler({
+    method: 'POST',
+    path: '/webhook/tatum/bitcoin',
+    version: '1.1',
+    headers,
+    req: { body } as any
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+describe('makeTatum plugin', () => {
+  let plugin: AddressPlugin
+  let mockRegistry: WebhookRegistry
+  let registeredHandler: WebhookRoute | null = null
+  let createResponses: Response[]
+  let deleteResponses: Response[]
+  let listResponses: Response[]
+  let putResponses: Response[]
+
+  function countCalls(method: string, path: string): number {
+    return mockFetch.mock.calls.filter(call => {
+      const url = String(call[0])
+      const init = call[1]
+      const requestMethod = (init?.method ?? 'GET').toUpperCase()
+      return requestMethod === method.toUpperCase() && url.includes(path)
+    }).length
+  }
+
+  /** Mock fetch: createSubscription success */
+  function mockSuccessfulCreate(subscriptionId = 'sub-001'): void {
+    createResponses.push(
+      makeMockResponse(true, 200, JSON.stringify({ id: subscriptionId }))
+    )
+  }
+
+  /** Mock fetch: deleteSubscription success */
+  function mockSuccessfulDelete(): void {
+    deleteResponses.push(makeMockResponse(true, 200, ''))
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    registeredHandler = null
+    createResponses = []
+    deleteResponses = []
+    listResponses = []
+    putResponses = []
+
+    mockFetch.mockImplementation(async (input, init?: RequestInit) => {
+      const url = String(input)
+      const method = (init?.method ?? 'GET').toUpperCase()
+
+      if (method === 'GET' && url.includes('/v4/subscription?')) {
+        return listResponses.shift() ?? makeMockResponse(true, 200, '[]')
+      }
+      if (method === 'POST' && url.endsWith('/v4/subscription')) {
+        return (
+          createResponses.shift() ??
+          makeMockResponse(true, 200, JSON.stringify({ id: 'sub-default' }))
+        )
+      }
+      if (method === 'DELETE' && url.includes('/v4/subscription/')) {
+        return deleteResponses.shift() ?? makeMockResponse(true, 200, '')
+      }
+      if (method === 'PUT' && url.includes('/v4/subscription/')) {
+        return putResponses.shift() ?? makeMockResponse(true, 204, '')
+      }
+      return makeMockResponse(
+        false,
+        500,
+        `unexpected request: ${method} ${url}`
+      )
+    })
+
+    mockRegistry = {
+      registerHandler: jest.fn((_key: string, handler: WebhookRoute) => {
+        registeredHandler = handler
+      }),
+      unregisterHandler: jest.fn(),
+      handleWebhook: jest.fn(async () => ({ status: 200, body: 'OK' }))
+    }
+
+    plugin = makeTatum({
+      pluginId: 'bitcoin',
+      chain: 'bitcoin-mainnet',
+      webhookRegistry: mockRegistry
+    })
+  })
+
+  afterEach(() => {
+    plugin.destroy?.()
+    jest.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Instantiation
+  // -------------------------------------------------------------------------
+
+  describe('instantiation', () => {
+    test('sets pluginId correctly', () => {
+      expect(plugin.pluginId).toBe('bitcoin')
+    })
+
+    test('registers webhook handler with correct key', () => {
+      expect(mockRegistry.registerHandler).toHaveBeenCalledWith(
+        'tatum/bitcoin',
+        expect.any(Function)
+      )
+    })
+
+    test('exposes an on() event emitter', () => {
+      expect(typeof plugin.on).toBe('function')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // subscribe / unsubscribe
+  // -------------------------------------------------------------------------
+
+  describe('subscribe', () => {
+    test('returns true on success', async () => {
+      mockSuccessfulCreate()
+      expect(await plugin.subscribe('0xABC123')).toBe(true)
+    })
+
+    test('preserves address case by default', async () => {
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xABC123')
+      // Verify the API was called with original-case address in body
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining('0xABC123')
+        })
+      )
+    })
+
+    test('is idempotent — second call skips API', async () => {
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+      const result = await plugin.subscribe('0xabc123')
+      expect(result).toBe(true)
+      expect(countCalls('POST', '/v4/subscription')).toBe(1)
+    })
+
+    test('returns false when API call fails after max retries', async () => {
+      createResponses = [
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error')
+      ]
+      const result = await plugin.subscribe('0xfail123')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('unsubscribe', () => {
+    test('returns false for unknown address', async () => {
+      expect(await plugin.unsubscribe('0xunknown')).toBe(false)
+    })
+
+    test('returns true and calls delete API', async () => {
+      mockSuccessfulCreate()
+      mockSuccessfulDelete()
+      await plugin.subscribe('0xabc123')
+      expect(await plugin.unsubscribe('0xabc123')).toBe(true)
+    })
+
+    test('removes address from subscriptions', async () => {
+      mockSuccessfulCreate()
+      mockSuccessfulDelete()
+      await plugin.subscribe('0xabc123')
+      await plugin.unsubscribe('0xabc123')
+      // Second unsubscribe should return false
+      expect(await plugin.unsubscribe('0xabc123')).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Webhook verification
+  // -------------------------------------------------------------------------
+
+  describe('webhook signature verification', () => {
+    test('accepts request with valid signature', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+      const body = buildPayload({ address: '0xabc123' })
+      const response = await callHandler(registeredHandler, body)
+      expect(response.status).toBe(200)
+    })
+
+    test('rejects request with missing signature header', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+      const body = buildPayload()
+      const response = await callHandlerRaw(registeredHandler, body, {})
+      expect(response.status).toBe(401)
+    })
+
+    test('rejects request with invalid signature', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+      const body = buildPayload()
+      const response = await callHandlerRaw(registeredHandler, body, {
+        'x-tatum-signature': 'bad-signature-value'
+      })
+      expect(response.status).toBe(401)
+    })
+
+    test('rejects request with signature for different body', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+      const correctBody = buildPayload({ address: '0xabc' })
+      const tamperedBody = buildPayload({ address: '0xevil' })
+      const sig = computeSignature(correctBody, TEST_HMAC_SECRET)
+      const response = await callHandlerRaw(registeredHandler, tamperedBody, {
+        'x-tatum-signature': sig
+      })
+      expect(response.status).toBe(401)
+    })
+
+    test('rejects malformed JSON payload with 400', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+      const invalidBody = 'not-valid-json'
+      const sig = computeSignature(invalidBody, TEST_HMAC_SECRET)
+      const response = await callHandlerRaw(registeredHandler, invalidBody, {
+        'x-tatum-signature': sig
+      })
+      expect(response.status).toBe(400)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Idempotency
+  // -------------------------------------------------------------------------
+
+  describe('idempotency', () => {
+    test('emits update for first delivery', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      const body = buildPayload({ address: '0xabc123', txId: 'tx-unique-001' })
+      const response = await callHandler(registeredHandler, body)
+
+      expect(response.status).toBe(200)
+      expect(updateHandler).toHaveBeenCalledTimes(1)
+    })
+
+    test('returns 200 but does NOT re-emit for duplicate txId', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      const body = buildPayload({ address: '0xabc123', txId: 'tx-dupe-001' })
+
+      // First delivery
+      await callHandler(registeredHandler, body)
+      // Duplicate delivery
+      const duplicate = await callHandler(registeredHandler, body)
+
+      expect(duplicate.status).toBe(200)
+      expect(updateHandler).toHaveBeenCalledTimes(1) // Only once
+    })
+
+    test('processes events without txId every time', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      // Payload with no txId — cannot deduplicate, always processes
+      const body = buildPayload({ address: '0xabc123', txId: undefined })
+
+      await callHandler(registeredHandler, body)
+      await callHandler(registeredHandler, body)
+
+      expect(updateHandler).toHaveBeenCalledTimes(2)
+    })
+
+    test('distinct txIds are each processed once', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      for (let i = 0; i < 5; i++) {
+        const body = buildPayload({ address: '0xabc123', txId: `tx-${i}` })
+        await callHandler(registeredHandler, body)
+      }
+
+      expect(updateHandler).toHaveBeenCalledTimes(5)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Event emission
+  // -------------------------------------------------------------------------
+
+  describe('update event emission', () => {
+    test('emits update with blockNumber as checkpoint for tracked address', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      const body = buildPayload({
+        address: '0xabc123',
+        txId: 'tx-block-check',
+        blockNumber: 999
+      })
+      await callHandler(registeredHandler, body)
+
+      expect(updateHandler).toHaveBeenCalledWith({
+        address: '0xabc123',
+        checkpoint: '999'
+      })
+    })
+
+    test('emits update with undefined checkpoint when blockNumber missing', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      mockSuccessfulCreate()
+      await plugin.subscribe('0xabc123')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      const body = buildPayload({
+        address: '0xabc123',
+        txId: 'tx-no-block',
+        blockNumber: undefined
+      })
+      await callHandler(registeredHandler, body)
+
+      expect(updateHandler).toHaveBeenCalledWith({
+        address: '0xabc123',
+        checkpoint: undefined
+      })
+    })
+
+    test('does NOT emit update for unsubscribed address', async () => {
+      if (registeredHandler == null) throw new Error('handler not registered')
+
+      const updateHandler = jest.fn()
+      plugin.on('update', updateHandler)
+
+      const body = buildPayload({ address: '0xuntracked', txId: 'tx-xx' })
+      await callHandler(registeredHandler, body)
+
+      expect(updateHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Retry / backoff for subscription API calls
+  // -------------------------------------------------------------------------
+
+  describe('retry/backoff for API calls', () => {
+    test('retries on HTTP 5xx and eventually succeeds', async () => {
+      // First two attempts fail with 500, third succeeds
+      mockFetch
+        .mockResolvedValueOnce(makeMockResponse(false, 500, 'internal error'))
+        .mockResolvedValueOnce(makeMockResponse(false, 503, 'unavailable'))
+        .mockResolvedValueOnce(
+          makeMockResponse(true, 200, JSON.stringify({ id: 'sub-after-retry' }))
+        )
+
+      const result = await plugin.subscribe('0xretry')
+      expect(result).toBe(true)
+      expect(countCalls('POST', '/v4/subscription')).toBe(3)
+    })
+
+    test('retries on HTTP 429 rate limit', async () => {
+      mockFetch
+        .mockResolvedValueOnce(makeMockResponse(false, 429, 'rate limited'))
+        .mockResolvedValueOnce(
+          makeMockResponse(true, 200, JSON.stringify({ id: 'sub-after-429' }))
+        )
+
+      const result = await plugin.subscribe('0xratelimited')
+      expect(result).toBe(true)
+      expect(countCalls('POST', '/v4/subscription')).toBe(2)
+    })
+
+    test('returns false after MAX_API_RETRIES (5) failures', async () => {
+      createResponses = [
+        makeMockResponse(false, 500, 'always fails'),
+        makeMockResponse(false, 500, 'always fails'),
+        makeMockResponse(false, 500, 'always fails'),
+        makeMockResponse(false, 500, 'always fails'),
+        makeMockResponse(false, 500, 'always fails')
+      ]
+
+      const result = await plugin.subscribe('0xalwaysfails')
+      expect(result).toBe(false)
+      expect(countCalls('POST', '/v4/subscription')).toBe(5)
+    })
+
+    test('does not retry on 4xx client errors (non-429)', async () => {
+      createResponses = [makeMockResponse(false, 400, 'bad req')]
+
+      const result = await plugin.subscribe('0xbadreq')
+      expect(result).toBe(false)
+      // Should NOT retry on 400 client errors:
+      expect(countCalls('POST', '/v4/subscription')).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Subscription ownership boundary (no cross-server takeover)
+  // -------------------------------------------------------------------------
+
+  describe('subscription ownership boundary', () => {
+    test('reuses owned existing subscription on 403 exists error', async () => {
+      createResponses = [
+        makeMockResponse(
+          false,
+          403,
+          JSON.stringify({
+            errorCode: 'subscription.exists.on.address-and-currency',
+            message: 'Subscription exists'
+          })
+        )
+      ]
+      listResponses = [
+        makeMockResponse(
+          true,
+          200,
+          JSON.stringify([
+            {
+              id: 'sub-owned',
+              type: 'ADDRESS_EVENT',
+              attr: {
+                address: '0xowned',
+                chain: 'bitcoin-mainnet',
+                url: 'https://test.edge.app/webhook/tatum/bitcoin'
+              }
+            }
+          ])
+        )
+      ]
+
+      const result = await plugin.subscribe('0xowned')
+      expect(result).toBe(true)
+    })
+
+    test('rejects foreign subscription on 403 exists error', async () => {
+      createResponses = [
+        makeMockResponse(
+          false,
+          403,
+          JSON.stringify({
+            errorCode: 'subscription.exists.on.address-and-currency',
+            message: 'Subscription exists'
+          })
+        )
+      ]
+      listResponses = [
+        makeMockResponse(
+          true,
+          200,
+          JSON.stringify([
+            {
+              id: 'sub-foreign',
+              type: 'ADDRESS_EVENT',
+              attr: {
+                address: '0xforeign',
+                chain: 'bitcoin-mainnet',
+                url: 'https://other-server.example.com/webhook/tatum/bitcoin'
+              }
+            }
+          ])
+        )
+      ]
+
+      const result = await plugin.subscribe('0xforeign')
+      expect(result).toBe(false)
+      expect(countCalls('PUT', '/v4/subscription/')).toBe(0)
+    })
+
+    test('fails when no matching subscription found on 403 exists error', async () => {
+      createResponses = [
+        makeMockResponse(
+          false,
+          403,
+          JSON.stringify({
+            errorCode: 'subscription.exists.on.address-and-currency',
+            message: 'Subscription exists'
+          })
+        )
+      ]
+      listResponses = [makeMockResponse(true, 200, '[]')]
+
+      const result = await plugin.subscribe('0xghost')
+      expect(result).toBe(false)
+    })
+
+    test('updates owned subscription URL if stale on 403 exists', async () => {
+      createResponses = [
+        makeMockResponse(
+          false,
+          403,
+          JSON.stringify({
+            errorCode: 'subscription.exists.on.address-and-currency',
+            message: 'Subscription exists'
+          })
+        )
+      ]
+      listResponses = [
+        makeMockResponse(
+          true,
+          200,
+          JSON.stringify([
+            {
+              id: 'sub-stale',
+              type: 'ADDRESS_EVENT',
+              attr: {
+                address: '0xstale',
+                chain: 'bitcoin-mainnet',
+                url: 'https://test.edge.app/v1/webhook/tatum/bitcoin'
+              }
+            }
+          ])
+        )
+      ]
+      putResponses = [makeMockResponse(true, 204, '')]
+
+      const result = await plugin.subscribe('0xstale')
+      expect(result).toBe(true)
+      expect(countCalls('PUT', '/v4/subscription/')).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete failure propagation in unsubscribe
+  // -------------------------------------------------------------------------
+
+  describe('unsubscribe delete failure propagation', () => {
+    test('returns false when remote delete fails with non-retryable error', async () => {
+      mockSuccessfulCreate('sub-del-fail')
+      await plugin.subscribe('0xdelfail')
+
+      deleteResponses = [makeMockResponse(false, 403, 'forbidden')]
+
+      const result = await plugin.unsubscribe('0xdelfail')
+      expect(result).toBe(false)
+    })
+
+    test('preserves local subscription state on delete failure', async () => {
+      mockSuccessfulCreate('sub-del-fail2')
+      await plugin.subscribe('0xdelfail2')
+
+      deleteResponses = [makeMockResponse(false, 403, 'forbidden')]
+
+      await plugin.unsubscribe('0xdelfail2')
+      // Address should still be tracked since remote delete failed
+      mockSuccessfulDelete()
+      const secondResult = await plugin.unsubscribe('0xdelfail2')
+      expect(secondResult).toBe(true)
+    })
+
+    test('returns false when remote delete exhausts retries', async () => {
+      mockSuccessfulCreate('sub-del-retry')
+      await plugin.subscribe('0xdelretry')
+
+      deleteResponses = [
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error'),
+        makeMockResponse(false, 500, 'error')
+      ]
+
+      const result = await plugin.unsubscribe('0xdelretry')
+      expect(result).toBe(false)
+    })
+
+    test('succeeds and clears state on 404 (already deleted)', async () => {
+      mockSuccessfulCreate('sub-del-404')
+      await plugin.subscribe('0xdel404')
+
+      deleteResponses = [makeMockResponse(false, 404, 'not found')]
+
+      const result = await plugin.unsubscribe('0xdel404')
+      expect(result).toBe(true)
+      expect(await plugin.unsubscribe('0xdel404')).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // destroy
+  // -------------------------------------------------------------------------
+
+  describe('destroy', () => {
+    test('unregisters webhook handler', () => {
+      plugin.destroy?.()
+      expect(mockRegistry.unregisterHandler).toHaveBeenCalledWith(
+        'tatum/bitcoin',
+        expect.any(Function)
+      )
+    })
+
+    test('does not delete remote subscriptions on destroy', async () => {
+      mockSuccessfulCreate('sub-to-clean')
+      await plugin.subscribe('0xclean')
+
+      plugin.destroy?.()
+
+      // Allow microtasks to flush
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(countCalls('DELETE', '/v4/subscription/')).toBe(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Chain map tests
+// ---------------------------------------------------------------------------
+
+describe('tatumChainMap', () => {
+  test('contains exactly 7 entries', () => {
+    expect(Object.keys(tatumChainMap)).toHaveLength(7)
+  })
+
+  test('TATUM_PLUGIN_IDS matches tatumChainMap keys', () => {
+    const mapKeys = Object.keys(tatumChainMap).sort((a, b) =>
+      a.localeCompare(b)
+    )
+    const idsKeys = [...TATUM_PLUGIN_IDS].sort((a, b) => a.localeCompare(b))
+    expect(idsKeys).toEqual(mapKeys)
+  })
+
+  test.each([
+    ['bitcoin', 'bitcoin-mainnet'],
+    ['bitcoincash', 'bch-mainnet'],
+    ['dogecoin', 'doge-mainnet'],
+    ['litecoin', 'litecoin-core-mainnet'],
+    ['ripple', 'ripple-mainnet'],
+    ['tezos', 'tezos-mainnet'],
+    ['tron', 'tron-mainnet']
+  ])('maps %s → %s', (pluginId, chain) => {
+    expect(tatumChainMap[pluginId]).toBe(chain)
+  })
+
+  test('all chain values end with -mainnet', () => {
+    for (const chain of Object.values(tatumChainMap)) {
+      expect(chain).toMatch(/(mainnet|core-mainnet)$/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: webhook → event flow
+// ---------------------------------------------------------------------------
+
+describe('integration: webhook → event processing → update emission', () => {
+  test('full flow: subscribe → receive webhook → emit update', async () => {
+    // NOTE: jest.fn() mock types prevent direct assignment-narrowing inside
+    // registerHandler callbacks. Capture via closure instead.
+    let capturedHandler: WebhookRoute | null = null
+
+    const webhookRegistry: WebhookRegistry = {
+      registerHandler: jest.fn((_key: string, handler: WebhookRoute) => {
+        capturedHandler = handler
+      }),
+      unregisterHandler: jest.fn(),
+      handleWebhook: jest.fn(async () => ({ status: 200, body: 'OK' }))
+    }
+
+    const mockFetchIntegration = jest.fn<typeof fetch>()
+    global.fetch = mockFetchIntegration as typeof fetch
+    mockFetchIntegration.mockResolvedValueOnce(
+      makeMockResponse(true, 200, '[]')
+    )
+    mockFetchIntegration.mockResolvedValueOnce(
+      makeMockResponse(true, 200, JSON.stringify({ id: 'integration-sub-001' }))
+    )
+
+    const p = makeTatum({
+      pluginId: 'bitcoin',
+      chain: 'bitcoin-mainnet',
+      webhookRegistry
+    })
+
+    const updateEvents: Array<{ address: string; checkpoint?: string }> = []
+    p.on('update', evt => updateEvents.push(evt))
+
+    // Step 1: Subscribe
+    const subscribed = await p.subscribe('1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2')
+    expect(subscribed).toBe(true)
+
+    // Step 2: Simulate Tatum webhook delivery
+    if (capturedHandler == null) throw new Error('Handler not captured')
+    const handler = capturedHandler as WebhookRoute
+
+    const testAddress = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+    const body = JSON.stringify({
+      address: testAddress,
+      txId: 'btc-tx-123abc',
+      blockNumber: 820000,
+      type: 'native',
+      chain: 'bitcoin-mainnet',
+      subscriptionType: 'ADDRESS_EVENT'
+    })
+
+    const sig = computeSignature(body, TEST_HMAC_SECRET)
+    const response = await handler({
+      method: 'POST',
+      path: '/webhook/tatum/bitcoin',
+      version: '1.1',
+      headers: { 'x-tatum-signature': sig },
+      req: { body } as any
+    })
+
+    // Step 3: Assert
+    expect(response.status).toBe(200)
+    expect(updateEvents).toHaveLength(1)
+    expect(updateEvents[0]).toEqual({
+      address: testAddress,
+      checkpoint: '820000'
+    })
+
+    p.destroy?.()
+
+    // Restore global fetch to the shared mock
+    global.fetch = mockFetch as typeof fetch
+  })
+})


### PR DESCRIPTION
We need dependable address activity detection on chains where existing providers were missing coverage or produced inconsistent updates in production.

Using Tatum as the common integration point reduces monitoring blind spots and makes webhook event handling more reliable under real-world delivery behavior.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external-provider integration (Tatum) that creates/deletes remote subscriptions and handles inbound webhooks with signature verification and deduplication; mistakes could cause missed updates or rejected webhooks. Scoped to new plugin + config and is covered by dedicated unit tests, reducing but not eliminating operational risk.
> 
> **Overview**
> Adds a new Tatum-backed webhook plugin (`makeTatum`) that creates per-address `ADDRESS_EVENT` subscriptions, verifies inbound `X-Tatum-Signature` HMAC (optional via config), deduplicates at-least-once deliveries, and emits `update` events with optional block-height checkpoints.
> 
> Registers seven new default plugins in `allPlugins` (**bitcoin, bitcoincash, dogecoin, litecoin, ripple, tezos, tron**) and adds `serverConfig.tatumHmacSecret` to control webhook signing/verification; includes new docs for adding plugins and for webhook-based plugin design, plus comprehensive tests for Tatum behavior (subscribe/unsubscribe, retries, ownership boundary, signature validation, idempotency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ab5d02062fa5cf8c4736820c18b5166c92d7fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213534402468634