### PR TITLE
feat: add Cosmos SDK WebSocket plugin for 7 chains (Cursor)

### DIFF
--- a/src/plugins/allPlugins.ts
+++ b/src/plugins/allPlugins.ts
@@ -3,6 +3,7 @@ import { AlchemyNotifyApi } from '../util/alchemyNotifyApi'
 import { SigningKeyStore } from '../util/signingKeyStore'
 import { WebhookRegistry } from '../util/webhookRegistry'
 import { makeAlchemy } from './alchemy'
+import { makeCosmosWs } from './cosmosWs'
 import { makeEvmRpc } from './evmRpc'
 import { makeFakePlugin } from './fakePlugin'
 
@@ -234,6 +235,66 @@ export function makeAllPlugins(opts: AllPluginOptions): AddressPlugin[] {
       signingKeyStore,
       webhookRegistry,
       normalizeAddress: evmNormalizeAddress
+    }),
+
+    // Cosmos SDK chains via Tendermint WebSocket:
+    makeCosmosWs({
+      pluginId: 'axelar',
+      wsUrl: 'wss://axelar.tendermintrpc.lava.build/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'coreum',
+      wsUrl: 'wss://full-node.mainnet-1.coreum.dev:26657/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'cosmoshub',
+      wsUrl: 'wss://cosmos-rpc.publicnode.com:443/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'mayachain',
+      wsUrl: 'wss://tendermint.mayachain.info/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'nym',
+      wsUrl: 'wss://rpc.nymtech.net:443/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'osmosis',
+      wsUrl: 'wss://rpc.osmosis.zone:443/websocket'
+    }),
+    makeCosmosWs({
+      pluginId: 'thorchainrune',
+      wsUrl: 'wss://rpc.ninerealms.com/websocket'
+    }),
+
+    // Cosmos SDK chains (Tendermint/CometBFT WebSocket):
+    makeCosmosWs({
+      pluginId: 'axelar',
+      wsUrl: 'https://axelar.tendermintrpc.lava.build'
+    }),
+    makeCosmosWs({
+      pluginId: 'coreum',
+      wsUrl: 'https://full-node.mainnet-1.coreum.dev:26657'
+    }),
+    makeCosmosWs({
+      pluginId: 'cosmoshub',
+      wsUrl: 'https://cosmos-rpc.publicnode.com:443'
+    }),
+    makeCosmosWs({
+      pluginId: 'mayachain',
+      wsUrl: 'https://tendermint.mayachain.info'
+    }),
+    makeCosmosWs({
+      pluginId: 'nym',
+      wsUrl: 'https://rpc.nymtech.net:443'
+    }),
+    makeCosmosWs({
+      pluginId: 'osmosis',
+      wsUrl: 'https://rpc.osmosis.zone:443'
+    }),
+    makeCosmosWs({
+      pluginId: 'thorchainrune',
+      wsUrl: 'https://rpc.ninerealms.com'
     }),
 
     // Testing:

--- a/src/plugins/cosmosWs.ts
+++ b/src/plugins/cosmosWs.ts
@@ -1,0 +1,282 @@
+import WebSocket from 'ws'
+import { makeEvents } from 'yavent'
+
+import { AddressPlugin, PluginEvents } from '../types/addressPlugin'
+import { makeLogger } from '../util/logger'
+
+export interface CosmosWsOptions {
+  pluginId: string
+  wsUrl: string
+}
+
+const ADDRESS_ATTRIBUTE_KEYS = [
+  'transfer.sender',
+  'transfer.recipient',
+  'message.sender',
+  'coin_spent.spender',
+  'coin_received.receiver'
+]
+
+const MIN_BACKOFF_MS = 1000
+const MAX_BACKOFF_MS = 30000
+
+function buildWsUrl(url: string): string {
+  // Convert https:// -> wss:// and http:// -> ws://
+  let wsUrl = url
+  if (wsUrl.startsWith('https://')) {
+    wsUrl = 'wss://' + wsUrl.slice('https://'.length)
+  } else if (wsUrl.startsWith('http://')) {
+    wsUrl = 'ws://' + wsUrl.slice('http://'.length)
+  }
+  // Append /websocket if not already present
+  if (!wsUrl.endsWith('/websocket')) {
+    wsUrl = wsUrl + '/websocket'
+  }
+  return wsUrl
+}
+
+export function makeCosmosWs(opts: CosmosWsOptions): AddressPlugin {
+  const { pluginId, wsUrl } = opts
+  const resolvedUrl = buildWsUrl(wsUrl)
+
+  const [on, emit] = makeEvents<PluginEvents>()
+  const logger = makeLogger('cosmosWs', pluginId)
+
+  // Subscribed addresses map: normalized -> original
+  const subscribedAddresses = new Map<string, string>()
+
+  let ws: WebSocket | null = null
+  let destroyed = false
+  let backoffMs = MIN_BACKOFF_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  function connect(): void {
+    if (destroyed) return
+
+    ws = new WebSocket(resolvedUrl)
+
+    ws.on('open', () => {
+      logger.info('connected')
+      backoffMs = MIN_BACKOFF_MS
+
+      // Subscribe to all Tx events
+      const subscribeMsg = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        id: 1,
+        params: { query: "tm.event='Tx'" }
+      })
+      const activeWs = ws
+      if (activeWs != null) {
+        activeWs.send(subscribeMsg)
+      }
+    })
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      const raw =
+        data instanceof Buffer
+          ? data.toString('utf8')
+          : data instanceof ArrayBuffer
+          ? Buffer.from(data).toString('utf8')
+          : Array.isArray(data)
+          ? Buffer.concat(data).toString('utf8')
+          : String(data)
+      handleMessage(raw)
+    })
+
+    ws.on('close', () => {
+      logger.warn('disconnected')
+      handleDisconnect()
+    })
+
+    ws.on('error', (err: Error) => {
+      logger.error({ err }, 'websocket error')
+      // close event will follow
+    })
+  }
+
+  function handleDisconnect(): void {
+    ws = null
+
+    // Emit subLost for all subscribed addresses
+    if (subscribedAddresses.size > 0) {
+      const addresses = Array.from(subscribedAddresses.values())
+      emit('subLost', { addresses })
+    }
+
+    if (!destroyed) {
+      scheduleReconnect()
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (destroyed) return
+    const delay = backoffMs
+    backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS)
+    logger.info({ delayMs: delay }, 'scheduling reconnect')
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      connect()
+    }, delay)
+  }
+
+  function handleMessage(raw: string): void {
+    let msg: unknown
+    try {
+      msg = JSON.parse(raw)
+    } catch {
+      logger.warn({ raw }, 'failed to parse message')
+      return
+    }
+
+    if (
+      msg == null ||
+      typeof msg !== 'object' ||
+      !('result' in msg) ||
+      msg.result == null ||
+      typeof msg.result !== 'object'
+    ) {
+      return
+    }
+
+    const result = msg.result as Record<string, unknown>
+
+    // Tendermint v0.35+ / CometBFT: events are on result.events as flat map
+    // e.g. { "transfer.sender": ["cosmos1..."], "transfer.recipient": ["cosmos1..."] }
+    const events = result.events
+    if (
+      events != null &&
+      typeof events === 'object' &&
+      !Array.isArray(events)
+    ) {
+      const eventsMap = events as Record<string, unknown>
+      const matchedAddresses = new Set<string>()
+
+      for (const key of ADDRESS_ATTRIBUTE_KEYS) {
+        const vals = eventsMap[key]
+        if (Array.isArray(vals)) {
+          for (const val of vals) {
+            if (typeof val === 'string') {
+              const normalized = val.trim()
+              if (subscribedAddresses.has(normalized)) {
+                matchedAddresses.add(normalized)
+              }
+            }
+          }
+        }
+      }
+
+      for (const addr of matchedAddresses) {
+        const original = subscribedAddresses.get(addr) ?? addr
+        emit('update', { address: original })
+      }
+      return
+    }
+
+    // Tendermint v0.34: events are in result.data.value.TxResult.result.events[]
+    if (
+      'data' in result &&
+      result.data != null &&
+      typeof result.data === 'object'
+    ) {
+      const data = result.data as Record<string, unknown>
+      if (
+        'value' in data &&
+        data.value != null &&
+        typeof data.value === 'object'
+      ) {
+        const value = data.value as Record<string, unknown>
+        if (
+          'TxResult' in value &&
+          value.TxResult != null &&
+          typeof value.TxResult === 'object'
+        ) {
+          const txResult = value.TxResult as Record<string, unknown>
+          if (
+            'result' in txResult &&
+            txResult.result != null &&
+            typeof txResult.result === 'object'
+          ) {
+            const txResultInner = txResult.result as Record<string, unknown>
+            if (Array.isArray(txResultInner.events)) {
+              const matchedAddresses = new Set<string>()
+              for (const event of txResultInner.events) {
+                if (event == null || typeof event !== 'object') continue
+                const ev = event as {
+                  type?: string
+                  attributes?: Array<{ key: string; value: string }>
+                }
+                if (!Array.isArray(ev.attributes)) continue
+                const evType = ev.type ?? ''
+                for (const attr of ev.attributes) {
+                  if (attr == null) continue
+                  const key = decodeBase64OrRaw(attr.key)
+                  const val = decodeBase64OrRaw(attr.value)
+                  const fullKey = evType !== '' ? `${evType}.${key}` : key
+                  if (ADDRESS_ATTRIBUTE_KEYS.includes(fullKey)) {
+                    const normalized = val.trim()
+                    if (subscribedAddresses.has(normalized)) {
+                      matchedAddresses.add(normalized)
+                    }
+                  }
+                }
+              }
+              for (const addr of matchedAddresses) {
+                const original = subscribedAddresses.get(addr) ?? addr
+                emit('update', { address: original })
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function decodeBase64OrRaw(val: string): string {
+    try {
+      const decoded = Buffer.from(val, 'base64').toString('utf8')
+      // Only use decoded value if it looks like printable text
+      if (/^[\x20-\x7E]+$/.test(decoded)) {
+        return decoded
+      }
+    } catch {
+      // fall through
+    }
+    return val
+  }
+
+  // Start connection
+  connect()
+
+  return {
+    pluginId,
+    on,
+
+    async subscribe(address: string): Promise<boolean> {
+      const normalized = address.trim()
+      if (subscribedAddresses.has(normalized)) return false
+      subscribedAddresses.set(normalized, address)
+      return true
+    },
+
+    async unsubscribe(address: string): Promise<boolean> {
+      const normalized = address.trim()
+      if (!subscribedAddresses.has(normalized)) return false
+      subscribedAddresses.delete(normalized)
+      return true
+    },
+
+    destroy(): void {
+      destroyed = true
+      if (reconnectTimer != null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (ws != null) {
+        ws.removeAllListeners()
+        ws.close()
+        ws = null
+      }
+    }
+  }
+}

--- a/test/plugins/cosmosWs.test.ts
+++ b/test/plugins/cosmosWs.test.ts
@@ -1,0 +1,286 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from '@jest/globals'
+import { EventEmitter } from 'events'
+
+import { makeCosmosWs } from '../../src/plugins/cosmosWs'
+
+// Shared instances array, populated by the mock constructor
+let mockWsInstances: MockWebSocket[] = []
+
+interface MockWebSocket extends EventEmitter {
+  url: string
+  readyState: number
+  sent: string[]
+  close: () => void
+  send: (data: string) => void
+}
+
+jest.mock('ws', () => {
+  const { EventEmitter: EE } = jest.requireActual<typeof import('events')>(
+    'events'
+  )
+
+  class MockWebSocketImpl extends EE {
+    public readyState: number = 1
+    public sent: string[] = []
+
+    constructor(public url: string) {
+      super()
+      // Push to the shared instances array (accessed via closure trick below)
+      ;(MockWebSocketImpl as any).__instances.push(this)
+    }
+
+    send(data: string): void {
+      this.sent.push(data)
+    }
+
+    close(): void {
+      this.readyState = 3
+    }
+
+    removeAllListeners(): this {
+      return super.removeAllListeners()
+    }
+  }
+
+  ;(MockWebSocketImpl as any).__instances = []
+
+  return MockWebSocketImpl
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const WsMock: any = jest.requireMock('ws')
+
+function resetInstances(): void {
+  WsMock.__instances = []
+  mockWsInstances = WsMock.__instances as MockWebSocket[]
+}
+
+function getLastWs(): MockWebSocket {
+  return mockWsInstances[mockWsInstances.length - 1]
+}
+
+function makeTxEvent(eventData: Record<string, string[]>): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      query: "tm.event='Tx'",
+      data: { type: 'tendermint/event/Tx', value: {} },
+      events: eventData
+    }
+  })
+}
+
+describe('makeCosmosWs', () => {
+  beforeEach(() => {
+    resetInstances()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('subscribes to Tx events on connect', () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    expect(ws.sent).toHaveLength(1)
+    const msg = JSON.parse(ws.sent[0])
+    expect(msg.method).toBe('subscribe')
+    expect(msg.params.query).toBe("tm.event='Tx'")
+
+    plugin.destroy?.()
+  })
+
+  it('subscribe/unsubscribe manages addresses', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+
+    const r1 = await plugin.subscribe('cosmos1abc')
+    expect(r1).toBe(true)
+
+    const r2 = await plugin.unsubscribe('cosmos1abc')
+    expect(r2).toBe(true)
+
+    const r3 = await plugin.unsubscribe('cosmos1abc')
+    expect(r3).toBe(false)
+
+    plugin.destroy?.()
+  })
+
+  it('emits update for matching transfer.sender', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1sender123')
+
+    const updates: string[] = []
+    plugin.on('update', ({ address }) => updates.push(address))
+
+    ws.emit('message', makeTxEvent({ 'transfer.sender': ['cosmos1sender123'] }))
+    expect(updates).toEqual(['cosmos1sender123'])
+
+    plugin.destroy?.()
+  })
+
+  it('emits update for matching transfer.recipient', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1recipient456')
+
+    const updates: string[] = []
+    plugin.on('update', ({ address }) => updates.push(address))
+
+    ws.emit(
+      'message',
+      makeTxEvent({ 'transfer.recipient': ['cosmos1recipient456'] })
+    )
+    expect(updates).toEqual(['cosmos1recipient456'])
+
+    plugin.destroy?.()
+  })
+
+  it('emits update for matching coin_spent.spender', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1spender789')
+
+    const updates: string[] = []
+    plugin.on('update', ({ address }) => updates.push(address))
+
+    ws.emit(
+      'message',
+      makeTxEvent({ 'coin_spent.spender': ['cosmos1spender789'] })
+    )
+    expect(updates).toEqual(['cosmos1spender789'])
+
+    plugin.destroy?.()
+  })
+
+  it('does not emit update for non-subscribed addresses', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1subscribed')
+
+    const updates: string[] = []
+    plugin.on('update', ({ address }) => updates.push(address))
+
+    ws.emit('message', makeTxEvent({ 'transfer.sender': ['cosmos1other'] }))
+    expect(updates).toHaveLength(0)
+
+    plugin.destroy?.()
+  })
+
+  it('emits subLost on close with subscribed addresses', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1a')
+    await plugin.subscribe('cosmos1b')
+
+    const subLostEvents: string[][] = []
+    plugin.on('subLost', ({ addresses }) => subLostEvents.push(addresses))
+
+    ws.emit('close')
+
+    expect(subLostEvents).toHaveLength(1)
+    expect(subLostEvents[0]).toContain('cosmos1a')
+    expect(subLostEvents[0]).toContain('cosmos1b')
+
+    plugin.destroy?.()
+  })
+
+  it('reconnects with exponential backoff after disconnect', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws1 = getLastWs()
+    ws1.emit('open')
+    ws1.emit('close')
+
+    // First reconnect after 1000ms
+    expect(mockWsInstances).toHaveLength(1)
+    jest.advanceTimersByTime(1000)
+    expect(mockWsInstances).toHaveLength(2)
+
+    const ws2 = getLastWs()
+    ws2.emit('open')
+    ws2.emit('close')
+
+    // Second reconnect after 2000ms
+    jest.advanceTimersByTime(2000)
+    expect(mockWsInstances).toHaveLength(3)
+
+    plugin.destroy?.()
+  })
+
+  it('does not reconnect after destroy', () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+    plugin.destroy?.()
+
+    jest.advanceTimersByTime(60000)
+    expect(mockWsInstances).toHaveLength(1)
+  })
+
+  it('ignores messages with no matching event attributes', async () => {
+    const plugin = makeCosmosWs({
+      pluginId: 'test',
+      wsUrl: 'wss://test.example.com/websocket'
+    })
+    const ws = getLastWs()
+    ws.emit('open')
+
+    await plugin.subscribe('cosmos1test')
+
+    const updates: string[] = []
+    plugin.on('update', ({ address }) => updates.push(address))
+
+    ws.emit('message', JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }))
+    expect(updates).toHaveLength(0)
+
+    plugin.destroy?.()
+  })
+})


### PR DESCRIPTION
Implement generic Tendermint/CometBFT WebSocket subscriber for Cosmos SDK chains.

## Chains
axelar, coreum, cosmoshub, mayachain, nym, osmosis, thorchainrune

## How it works
- Connects to each chain's Tendermint RPC WebSocket
- Subscribes to all Tx events and filters locally for subscribed addresses
- Parses transfer.sender, transfer.recipient, message.sender, coin_spent.spender, coin_received.receiver
- Reconnects with exponential backoff on connection loss
- Emits subLost on disconnect, update on address match

## Made with
Cursor

Relates to Asana task 1213534410513099